### PR TITLE
Make indexing lossless: bulk ingest with surfaced failures

### DIFF
--- a/src/main/java/il/org/osm/israelhiking/AccountingBulkListener.java
+++ b/src/main/java/il/org/osm/israelhiking/AccountingBulkListener.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.logging.Logger;
 
@@ -28,7 +29,7 @@ import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 
 final class AccountingBulkListener implements BulkListener<Void> {
-  private static final Logger LOGGER = Logger.getLogger(PlanetSearchProfile.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(AccountingBulkListener.class.getName());
 
   static final int MAX_RETRY_ATTEMPTS = 5;
   static final long DEFAULT_BASE_BACKOFF_MILLIS = 1_000L;
@@ -44,6 +45,8 @@ final class AccountingBulkListener implements BulkListener<Void> {
   private final long baseBackoffMillis;
   private final long maxBackoffMillis;
   private final long drainTimeoutMillis;
+  private final AtomicBoolean drained = new AtomicBoolean(false);
+  private final AtomicBoolean ingesterClosed = new AtomicBoolean(false);
 
   AccountingBulkListener(ElasticsearchClient esClient, IndexingStats stats) {
     this(esClient, stats, DEFAULT_BASE_BACKOFF_MILLIS, DEFAULT_MAX_BACKOFF_MILLIS,
@@ -76,11 +79,12 @@ final class AccountingBulkListener implements BulkListener<Void> {
 
   @Override
   public void afterBulk(long executionId, BulkRequest request, List<Void> contexts, BulkResponse response) {
-    if (!response.errors() && response.items().size() == request.operations().size()) {
-      indexedCount.add(response.items().size());
+    List<BulkResponseItem> items = response.items() == null ? List.of() : response.items();
+    if (!response.errors() && items.size() == request.operations().size()) {
+      indexedCount.add(items.size());
       return;
     }
-    List<BulkOperation> retryable = classifyAndCount(request.operations(), response);
+    List<BulkOperation> retryable = classifyAndCount(request.operations(), items);
     if (!retryable.isEmpty()) {
       LOGGER.warning(() -> "Bulk request " + executionId + " had " + retryable.size()
           + " retryable per-item failure(s); resubmitting with backoff.");
@@ -130,6 +134,9 @@ final class AccountingBulkListener implements BulkListener<Void> {
 
   // Must drain before the alias swap, else in-flight retry docs race the swap.
   void awaitRetries() {
+    if (!drained.compareAndSet(false, true)) {
+      return;
+    }
     retryExecutor.shutdown();
     try {
       if (!retryExecutor.awaitTermination(drainTimeoutMillis, TimeUnit.MILLISECONDS)) {
@@ -141,6 +148,10 @@ final class AccountingBulkListener implements BulkListener<Void> {
       Thread.currentThread().interrupt();
       chargeDropped(retryExecutor.shutdownNow());
     }
+  }
+
+  boolean tryClaimIngesterClose() {
+    return ingesterClosed.compareAndSet(false, true);
   }
 
   private void chargeDropped(List<Runnable> dropped) {
@@ -162,7 +173,8 @@ final class AccountingBulkListener implements BulkListener<Void> {
       }
       final List<BulkOperation> batch = pending;
       try {
-        pending = classifyAndCount(batch, esClient.bulk(BulkRequest.of(b -> b.operations(batch))));
+        BulkResponse response = esClient.bulk(BulkRequest.of(b -> b.operations(batch)));
+        pending = classifyAndCount(batch, response.items() == null ? List.of() : response.items());
         if (pending.isEmpty()) {
           final int n = batch.size();
           final int a = attemptNo;
@@ -191,9 +203,8 @@ final class AccountingBulkListener implements BulkListener<Void> {
     }
   }
 
-  private List<BulkOperation> classifyAndCount(List<BulkOperation> operations, BulkResponse response) {
+  private List<BulkOperation> classifyAndCount(List<BulkOperation> operations, List<BulkResponseItem> items) {
     List<BulkOperation> retryable = new ArrayList<>();
-    List<BulkResponseItem> items = response.items();
     for (int i = 0; i < operations.size(); i++) {
       BulkResponseItem item = i < items.size() ? items.get(i) : null;
       // null: op missing from a short response, retry so it can't vanish from accounting.

--- a/src/main/java/il/org/osm/israelhiking/AccountingBulkListener.java
+++ b/src/main/java/il/org/osm/israelhiking/AccountingBulkListener.java
@@ -21,6 +21,7 @@ import org.apache.http.conn.ConnectTimeoutException;
 import org.elasticsearch.client.ResponseException;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._helpers.bulk.BulkIngester;
 import co.elastic.clients.elasticsearch._helpers.bulk.BulkListener;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
@@ -28,7 +29,7 @@ import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 
-final class AccountingBulkListener implements BulkListener<Void> {
+final class AccountingBulkListener implements BulkListener<Void>, AutoCloseable {
   private static final Logger LOGGER = Logger.getLogger(AccountingBulkListener.class.getName());
 
   static final int MAX_RETRY_ATTEMPTS = 5;
@@ -47,6 +48,7 @@ final class AccountingBulkListener implements BulkListener<Void> {
   private final long drainTimeoutMillis;
   private final AtomicBoolean drained = new AtomicBoolean(false);
   private final AtomicBoolean ingesterClosed = new AtomicBoolean(false);
+  private volatile BulkIngester<Void> bulkIngester;
 
   AccountingBulkListener(ElasticsearchClient esClient, IndexingStats stats) {
     this(esClient, stats, DEFAULT_BASE_BACKOFF_MILLIS, DEFAULT_MAX_BACKOFF_MILLIS,
@@ -120,7 +122,6 @@ final class AccountingBulkListener implements BulkListener<Void> {
     }
   }
 
-  // Retries run off the ingester scheduler thread so backoff can't head-of-line-block ingest.
   private void offloadRetry(long executionId, List<BulkOperation> operations) {
     List<BulkOperation> batch = new ArrayList<>(operations);
     try {
@@ -132,7 +133,27 @@ final class AccountingBulkListener implements BulkListener<Void> {
     }
   }
 
-  // Must drain before the alias swap, else in-flight retry docs race the swap.
+  void attachIngester(BulkIngester<Void> ingester) {
+    this.bulkIngester = ingester;
+  }
+
+  // Idempotent: finalizeRun and the try-with-resources abort can both call it.
+  @Override
+  public void close() {
+    if (bulkIngester != null && ingesterClosed.compareAndSet(false, true)) {
+      try {
+        bulkIngester.close();
+      } catch (Exception e) {
+        LOGGER.warning("Bulk ingester close failed: " + e.getMessage());
+      }
+    }
+    awaitRetries();
+  }
+
+  boolean isDrained() {
+    return drained.get();
+  }
+
   void awaitRetries() {
     if (!drained.compareAndSet(false, true)) {
       return;
@@ -148,10 +169,6 @@ final class AccountingBulkListener implements BulkListener<Void> {
       Thread.currentThread().interrupt();
       chargeDropped(retryExecutor.shutdownNow());
     }
-  }
-
-  boolean tryClaimIngesterClose() {
-    return ingesterClosed.compareAndSet(false, true);
   }
 
   private void chargeDropped(List<Runnable> dropped) {
@@ -207,7 +224,6 @@ final class AccountingBulkListener implements BulkListener<Void> {
     List<BulkOperation> retryable = new ArrayList<>();
     for (int i = 0; i < operations.size(); i++) {
       BulkResponseItem item = i < items.size() ? items.get(i) : null;
-      // null: op missing from a short response, retry so it can't vanish from accounting.
       if (item == null || (item.error() != null && isRetryableStatus(item.status()))) {
         retryable.add(operations.get(i));
       } else if (item.error() == null) {
@@ -228,7 +244,6 @@ final class AccountingBulkListener implements BulkListener<Void> {
     return half + ThreadLocalRandom.current().nextLong(half + 1);
   }
 
-  // Per-item 4xx are non-retryable: resubmitting would loop forever.
   static boolean isRetryable(Throwable t) {
     Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
     for (Throwable c = t; c != null && seen.add(c); c = c.getCause()) {

--- a/src/main/java/il/org/osm/israelhiking/AccountingBulkListener.java
+++ b/src/main/java/il/org/osm/israelhiking/AccountingBulkListener.java
@@ -31,21 +31,38 @@ final class AccountingBulkListener implements BulkListener<Void> {
   private static final Logger LOGGER = Logger.getLogger(PlanetSearchProfile.class.getName());
 
   static final int MAX_RETRY_ATTEMPTS = 5;
-  static long BASE_BACKOFF_MILLIS = 1_000L;
-  static long MAX_BACKOFF_MILLIS = 16_000L;
+  static final long DEFAULT_BASE_BACKOFF_MILLIS = 1_000L;
+  static final long DEFAULT_MAX_BACKOFF_MILLIS = 16_000L;
 
   static final int RETRY_POOL_SIZE = 4;
-  static final long RETRY_DRAIN_TIMEOUT_MINUTES = 30;
+  static final long DEFAULT_DRAIN_TIMEOUT_MILLIS = 30 * 60 * 1_000L;
 
   private final ElasticsearchClient esClient;
   private final LongAdder indexedCount;
   private final LongAdder failedCount;
   private final ExecutorService retryExecutor;
+  private final long baseBackoffMillis;
+  private final long maxBackoffMillis;
+  private final long drainTimeoutMillis;
 
   AccountingBulkListener(ElasticsearchClient esClient, IndexingStats stats) {
+    this(esClient, stats, DEFAULT_BASE_BACKOFF_MILLIS, DEFAULT_MAX_BACKOFF_MILLIS,
+        DEFAULT_DRAIN_TIMEOUT_MILLIS);
+  }
+
+  AccountingBulkListener(ElasticsearchClient esClient, IndexingStats stats,
+      long baseBackoffMillis, long maxBackoffMillis) {
+    this(esClient, stats, baseBackoffMillis, maxBackoffMillis, DEFAULT_DRAIN_TIMEOUT_MILLIS);
+  }
+
+  AccountingBulkListener(ElasticsearchClient esClient, IndexingStats stats,
+      long baseBackoffMillis, long maxBackoffMillis, long drainTimeoutMillis) {
     this.esClient = esClient;
     this.indexedCount = stats.indexedCount;
     this.failedCount = stats.failedCount;
+    this.baseBackoffMillis = baseBackoffMillis;
+    this.maxBackoffMillis = maxBackoffMillis;
+    this.drainTimeoutMillis = drainTimeoutMillis;
     this.retryExecutor = Executors.newFixedThreadPool(RETRY_POOL_SIZE, r -> {
       Thread t = new Thread(r, "es-bulk-retry");
       t.setDaemon(true);
@@ -84,11 +101,26 @@ final class AccountingBulkListener implements BulkListener<Void> {
     }
   }
 
+  private final class RetryTask implements Runnable {
+    private final long executionId;
+    private final List<BulkOperation> batch;
+
+    RetryTask(long executionId, List<BulkOperation> batch) {
+      this.executionId = executionId;
+      this.batch = batch;
+    }
+
+    @Override
+    public void run() {
+      resubmitWithBackoff(executionId, batch);
+    }
+  }
+
   // Retries run off the ingester scheduler thread so backoff can't head-of-line-block ingest.
   private void offloadRetry(long executionId, List<BulkOperation> operations) {
     List<BulkOperation> batch = new ArrayList<>(operations);
     try {
-      retryExecutor.submit(() -> resubmitWithBackoff(executionId, batch));
+      retryExecutor.execute(new RetryTask(executionId, batch));
     } catch (RejectedExecutionException ree) {
       LOGGER.severe(() -> "Retry pool already shut down for bulk request " + executionId
           + "; counting " + batch.size() + " op(s) as failed.");
@@ -100,22 +132,28 @@ final class AccountingBulkListener implements BulkListener<Void> {
   void awaitRetries() {
     retryExecutor.shutdown();
     try {
-      if (!retryExecutor.awaitTermination(RETRY_DRAIN_TIMEOUT_MINUTES, TimeUnit.MINUTES)) {
-        LOGGER.severe("Bulk retries did not drain within " + RETRY_DRAIN_TIMEOUT_MINUTES
-            + " min; forcing shutdown — some re-indexed docs may not have landed before the alias swap.");
-        retryExecutor.shutdownNow();
+      if (!retryExecutor.awaitTermination(drainTimeoutMillis, TimeUnit.MILLISECONDS)) {
+        LOGGER.severe("Bulk retries did not drain within " + drainTimeoutMillis
+            + " ms; forcing shutdown — some re-indexed docs may not have landed before the alias swap.");
+        chargeDropped(retryExecutor.shutdownNow());
       }
     } catch (InterruptedException ie) {
       Thread.currentThread().interrupt();
-      retryExecutor.shutdownNow();
+      chargeDropped(retryExecutor.shutdownNow());
     }
+  }
+
+  private void chargeDropped(List<Runnable> dropped) {
+    dropped.stream()
+        .filter(RetryTask.class::isInstance)
+        .forEach(r -> ((RetryTask) r).batch.forEach(op -> failedCount.increment()));
   }
 
   private void resubmitWithBackoff(long executionId, List<BulkOperation> operations) {
     List<BulkOperation> pending = new ArrayList<>(operations);
     for (int attemptNo = 1; attemptNo <= MAX_RETRY_ATTEMPTS && !pending.isEmpty(); attemptNo++) {
       try {
-        Thread.sleep(backoffMillis(attemptNo));
+        Thread.sleep(backoffMillis(attemptNo, baseBackoffMillis, maxBackoffMillis));
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt();
         LOGGER.warning("Retry interrupted; charging remaining " + pending.size()
@@ -172,9 +210,9 @@ final class AccountingBulkListener implements BulkListener<Void> {
     return retryable;
   }
 
-  static long backoffMillis(int attempt) {
-    long exp = BASE_BACKOFF_MILLIS << (attempt - 1);
-    long capped = Math.min(exp, MAX_BACKOFF_MILLIS);
+  static long backoffMillis(int attempt, long baseBackoffMillis, long maxBackoffMillis) {
+    long exp = baseBackoffMillis << (attempt - 1);
+    long capped = Math.min(exp, maxBackoffMillis);
     long half = capped / 2;
     return half + ThreadLocalRandom.current().nextLong(half + 1);
   }

--- a/src/main/java/il/org/osm/israelhiking/AccountingBulkListener.java
+++ b/src/main/java/il/org/osm/israelhiking/AccountingBulkListener.java
@@ -1,0 +1,212 @@
+package il.org.osm.israelhiking;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.logging.Logger;
+
+import org.apache.http.conn.ConnectTimeoutException;
+import org.elasticsearch.client.ResponseException;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._helpers.bulk.BulkListener;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+
+final class AccountingBulkListener implements BulkListener<Void> {
+  private static final Logger LOGGER = Logger.getLogger(PlanetSearchProfile.class.getName());
+
+  static final int MAX_RETRY_ATTEMPTS = 5;
+  static long BASE_BACKOFF_MILLIS = 1_000L;
+  static long MAX_BACKOFF_MILLIS = 16_000L;
+
+  static final int RETRY_POOL_SIZE = 4;
+  static final long RETRY_DRAIN_TIMEOUT_MINUTES = 30;
+
+  private final ElasticsearchClient esClient;
+  private final LongAdder indexedCount;
+  private final LongAdder failedCount;
+  private final ExecutorService retryExecutor;
+
+  AccountingBulkListener(ElasticsearchClient esClient, IndexingStats stats) {
+    this.esClient = esClient;
+    this.indexedCount = stats.indexedCount;
+    this.failedCount = stats.failedCount;
+    this.retryExecutor = Executors.newFixedThreadPool(RETRY_POOL_SIZE, r -> {
+      Thread t = new Thread(r, "es-bulk-retry");
+      t.setDaemon(true);
+      return t;
+    });
+  }
+
+  @Override
+  public void beforeBulk(long executionId, BulkRequest request, List<Void> contexts) {
+  }
+
+  @Override
+  public void afterBulk(long executionId, BulkRequest request, List<Void> contexts, BulkResponse response) {
+    if (!response.errors() && response.items().size() == request.operations().size()) {
+      indexedCount.add(response.items().size());
+      return;
+    }
+    List<BulkOperation> retryable = classifyAndCount(request.operations(), response);
+    if (!retryable.isEmpty()) {
+      LOGGER.warning(() -> "Bulk request " + executionId + " had " + retryable.size()
+          + " retryable per-item failure(s); resubmitting with backoff.");
+      offloadRetry(executionId, retryable);
+    }
+  }
+
+  @Override
+  public void afterBulk(long executionId, BulkRequest request, List<Void> contexts, Throwable failure) {
+    if (isRetryable(failure)) {
+      LOGGER.warning(() -> "Bulk request " + executionId + " failed transiently ("
+          + describe(failure) + "); retrying with backoff.");
+      offloadRetry(executionId, request.operations());
+    } else {
+      LOGGER.severe(() -> "Bulk request " + executionId + " failed non-retryably ("
+          + describe(failure) + "); counting " + request.operations().size() + " op(s) as failed.");
+      request.operations().forEach(op -> failedCount.increment());
+    }
+  }
+
+  // Retries run off the ingester scheduler thread so backoff can't head-of-line-block ingest.
+  private void offloadRetry(long executionId, List<BulkOperation> operations) {
+    List<BulkOperation> batch = new ArrayList<>(operations);
+    try {
+      retryExecutor.submit(() -> resubmitWithBackoff(executionId, batch));
+    } catch (RejectedExecutionException ree) {
+      LOGGER.severe(() -> "Retry pool already shut down for bulk request " + executionId
+          + "; counting " + batch.size() + " op(s) as failed.");
+      batch.forEach(op -> failedCount.increment());
+    }
+  }
+
+  // Must drain before the alias swap, else in-flight retry docs race the swap.
+  void awaitRetries() {
+    retryExecutor.shutdown();
+    try {
+      if (!retryExecutor.awaitTermination(RETRY_DRAIN_TIMEOUT_MINUTES, TimeUnit.MINUTES)) {
+        LOGGER.severe("Bulk retries did not drain within " + RETRY_DRAIN_TIMEOUT_MINUTES
+            + " min; forcing shutdown — some re-indexed docs may not have landed before the alias swap.");
+        retryExecutor.shutdownNow();
+      }
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      retryExecutor.shutdownNow();
+    }
+  }
+
+  private void resubmitWithBackoff(long executionId, List<BulkOperation> operations) {
+    List<BulkOperation> pending = new ArrayList<>(operations);
+    for (int attemptNo = 1; attemptNo <= MAX_RETRY_ATTEMPTS && !pending.isEmpty(); attemptNo++) {
+      try {
+        Thread.sleep(backoffMillis(attemptNo));
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        LOGGER.warning("Retry interrupted; charging remaining " + pending.size()
+            + " op(s) as failed.");
+        break;
+      }
+      final List<BulkOperation> batch = pending;
+      try {
+        pending = classifyAndCount(batch, esClient.bulk(BulkRequest.of(b -> b.operations(batch))));
+        if (pending.isEmpty()) {
+          final int n = batch.size();
+          final int a = attemptNo;
+          LOGGER.info(() -> "Bulk request " + executionId + " recovered on retry attempt "
+              + a + " (" + n + " op(s) re-applied).");
+          return;
+        }
+      } catch (Exception e) {
+        if (!isRetryable(e)) {
+          LOGGER.severe(() -> "Retry of bulk request " + executionId
+              + " hit a non-retryable error (" + describe(e) + "); counting "
+              + batch.size() + " op(s) as failed.");
+          batch.forEach(op -> failedCount.increment());
+          return;
+        }
+        final int a = attemptNo;
+        LOGGER.warning(() -> "Retry attempt " + a + " for bulk request " + executionId
+            + " failed transiently (" + describe(e) + ").");
+      }
+    }
+    if (!pending.isEmpty()) {
+      final int n = pending.size();
+      LOGGER.warning(() -> "Bulk request " + executionId + " exhausted retries; counting "
+          + n + " op(s) as failed.");
+      pending.forEach(op -> failedCount.increment());
+    }
+  }
+
+  private List<BulkOperation> classifyAndCount(List<BulkOperation> operations, BulkResponse response) {
+    List<BulkOperation> retryable = new ArrayList<>();
+    List<BulkResponseItem> items = response.items();
+    for (int i = 0; i < operations.size(); i++) {
+      BulkResponseItem item = i < items.size() ? items.get(i) : null;
+      // null: op missing from a short response, retry so it can't vanish from accounting.
+      if (item == null || (item.error() != null && isRetryableStatus(item.status()))) {
+        retryable.add(operations.get(i));
+      } else if (item.error() == null) {
+        indexedCount.increment();
+      } else {
+        failedCount.increment();
+        LOGGER.warning(() -> "Failed to index id=" + item.id() + " into " + item.index()
+            + ": " + item.error().reason());
+      }
+    }
+    return retryable;
+  }
+
+  static long backoffMillis(int attempt) {
+    long exp = BASE_BACKOFF_MILLIS << (attempt - 1);
+    long capped = Math.min(exp, MAX_BACKOFF_MILLIS);
+    long half = capped / 2;
+    return half + ThreadLocalRandom.current().nextLong(half + 1);
+  }
+
+  // Per-item 4xx are non-retryable: resubmitting would loop forever.
+  static boolean isRetryable(Throwable t) {
+    Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+    for (Throwable c = t; c != null && seen.add(c); c = c.getCause()) {
+      if (c instanceof SocketTimeoutException
+          || c instanceof ConnectTimeoutException
+          || c instanceof ConnectException) {
+        return true;
+      }
+      if (c instanceof ResponseException re) {
+        return isRetryableStatus(re.getResponse().getStatusLine().getStatusCode());
+      }
+      if (c instanceof ElasticsearchException ese) {
+        return isRetryableStatus(ese.status());
+      }
+      if (c instanceof IOException) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean isRetryableStatus(int status) {
+    return status == 429 || status == 502 || status == 503 || status == 504;
+  }
+
+  private static String describe(Throwable t) {
+    String msg = t.getMessage();
+    return t.getClass().getSimpleName() + (msg == null ? "" : ": " + msg);
+  }
+}

--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -9,11 +9,15 @@ import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._helpers.bulk.BulkIngester;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.BackoffPolicy;
 import co.elastic.clients.transport.ElasticsearchTransport;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 
 public class ElasticsearchHelper {
+
+  private static final Logger LOGGER = Logger.getLogger(ElasticsearchHelper.class.getName());
 
   public static record ElasticRunContext(
       ElasticsearchClient esClient,
@@ -21,7 +25,10 @@ public class ElasticsearchHelper {
       String bboxIndexAlias,
       String pointsIndexTarget,
       String bboxIndexTarget,
-      String[] supportedLanguages) {
+      String[] supportedLanguages,
+      BulkIngester<Void> bulkIngester,
+      AccountingBulkListener bulkListener,
+      IndexingStats stats) {
   }
 
   /**
@@ -152,12 +159,40 @@ public class ElasticsearchHelper {
     var targetPointsIndex = ElasticsearchHelper.createPointsIndex(esClient, pointsIndexAlias,
         supportedLanguages);
     var targetBBoxIndex = ElasticsearchHelper.createBBoxIndex(esClient, bboxIndexAlias, supportedLanguages);
+    var stats = new IndexingStats();
+    var bulkListener = new AccountingBulkListener(esClient, stats);
+    BulkIngester<Void> bulkIngester = BulkIngester.of(b -> b
+        .client(esClient)
+        .maxOperations(5_000)
+        .maxSize(5 * 1024 * 1024)
+        .maxConcurrentRequests(4)
+        // noBackoff pinned: the listener owns retry, so the ingester must not double-retry.
+        .backoffPolicy(BackoffPolicy.noBackoff())
+        .listener(bulkListener));
     return new ElasticRunContext(esClient, pointsIndexAlias, bboxIndexAlias, targetPointsIndex, targetBBoxIndex,
-        supportedLanguages);
+        supportedLanguages, bulkIngester, bulkListener, stats);
   }
 
   public static void finalizeRun(ElasticRunContext context) throws Exception {
+    context.bulkIngester().flush();
+    context.bulkIngester().close();
+    context.bulkListener().awaitRetries();
+
+    var stats = context.stats();
+    LOGGER.info(() -> "Indexing finished: emitted=" + stats.getEmittedCount()
+        + " indexed=" + stats.getIndexedCount() + " failed=" + stats.getFailedCount());
+
     ElasticsearchHelper.switchAlias(context.esClient, context.pointsIndexAlias(), context.pointsIndexTarget());
     ElasticsearchHelper.switchAlias(context.esClient, context.bboxIndexAlias(), context.bboxIndexTarget());
+  }
+
+  // Releases ingester and retry executor without swapping aliases; safe in a finally after a failed run.
+  public static void abortRun(ElasticRunContext context) {
+    try {
+      context.bulkIngester().close();
+    } catch (Exception e) {
+      LOGGER.warning("Bulk ingester close failed during abort: " + e.getMessage());
+    }
+    context.bulkListener().awaitRetries();
   }
 }

--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -28,19 +28,7 @@ public class ElasticsearchHelper {
       String[] supportedLanguages,
       BulkIngester<Void> bulkIngester,
       AccountingBulkListener bulkListener,
-      IndexingStats stats) implements AutoCloseable {
-
-    @Override
-    public void close() {
-      if (bulkListener.tryClaimIngesterClose()) {
-        try {
-          bulkIngester.close();
-        } catch (Exception e) {
-          LOGGER.warning("Bulk ingester close failed during abort: " + e.getMessage());
-        }
-      }
-      bulkListener.awaitRetries();
-    }
+      IndexingStats stats) {
   }
 
   /**
@@ -178,19 +166,16 @@ public class ElasticsearchHelper {
         .maxOperations(5_000)
         .maxSize(5 * 1024 * 1024)
         .maxConcurrentRequests(4)
-        // noBackoff pinned: the listener owns retry, so the ingester must not double-retry.
         .backoffPolicy(BackoffPolicy.noBackoff())
         .listener(bulkListener));
+    bulkListener.attachIngester(bulkIngester);
     return new ElasticRunContext(esClient, pointsIndexAlias, bboxIndexAlias, targetPointsIndex, targetBBoxIndex,
         supportedLanguages, bulkIngester, bulkListener, stats);
   }
 
   public static void finalizeRun(ElasticRunContext context) throws Exception {
     context.bulkIngester().flush();
-    if (context.bulkListener().tryClaimIngesterClose()) {
-      context.bulkIngester().close();
-    }
-    context.bulkListener().awaitRetries();
+    context.bulkListener().close();
 
     var stats = context.stats();
     LOGGER.info(() -> "Indexing finished: emitted=" + stats.getEmittedCount()

--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -32,10 +32,12 @@ public class ElasticsearchHelper {
 
     @Override
     public void close() {
-      try {
-        bulkIngester.close();
-      } catch (Exception e) {
-        LOGGER.warning("Bulk ingester close failed during abort: " + e.getMessage());
+      if (bulkListener.tryClaimIngesterClose()) {
+        try {
+          bulkIngester.close();
+        } catch (Exception e) {
+          LOGGER.warning("Bulk ingester close failed during abort: " + e.getMessage());
+        }
       }
       bulkListener.awaitRetries();
     }
@@ -185,7 +187,9 @@ public class ElasticsearchHelper {
 
   public static void finalizeRun(ElasticRunContext context) throws Exception {
     context.bulkIngester().flush();
-    context.bulkIngester().close();
+    if (context.bulkListener().tryClaimIngesterClose()) {
+      context.bulkIngester().close();
+    }
     context.bulkListener().awaitRetries();
 
     var stats = context.stats();

--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -28,7 +28,17 @@ public class ElasticsearchHelper {
       String[] supportedLanguages,
       BulkIngester<Void> bulkIngester,
       AccountingBulkListener bulkListener,
-      IndexingStats stats) {
+      IndexingStats stats) implements AutoCloseable {
+
+    @Override
+    public void close() {
+      try {
+        bulkIngester.close();
+      } catch (Exception e) {
+        LOGGER.warning("Bulk ingester close failed during abort: " + e.getMessage());
+      }
+      bulkListener.awaitRetries();
+    }
   }
 
   /**
@@ -184,15 +194,5 @@ public class ElasticsearchHelper {
 
     ElasticsearchHelper.switchAlias(context.esClient, context.pointsIndexAlias(), context.pointsIndexTarget());
     ElasticsearchHelper.switchAlias(context.esClient, context.bboxIndexAlias(), context.bboxIndexTarget());
-  }
-
-  // Releases ingester and retry executor without swapping aliases; safe in a finally after a failed run.
-  public static void abortRun(ElasticRunContext context) {
-    try {
-      context.bulkIngester().close();
-    } catch (Exception e) {
-      LOGGER.warning("Bulk ingester close failed during abort: " + e.getMessage());
-    }
-    context.bulkListener().awaitRetries();
   }
 }

--- a/src/main/java/il/org/osm/israelhiking/IndexingStats.java
+++ b/src/main/java/il/org/osm/israelhiking/IndexingStats.java
@@ -1,0 +1,22 @@
+package il.org.osm.israelhiking;
+
+import java.util.concurrent.atomic.LongAdder;
+
+final class IndexingStats {
+
+  final LongAdder indexedCount = new LongAdder();
+  final LongAdder failedCount = new LongAdder();
+  final LongAdder emittedCount = new LongAdder();
+
+  long getIndexedCount() {
+    return indexedCount.sum();
+  }
+
+  long getFailedCount() {
+    return failedCount.sum();
+  }
+
+  long getEmittedCount() {
+    return emittedCount.sum();
+  }
+}

--- a/src/main/java/il/org/osm/israelhiking/MainClass.java
+++ b/src/main/java/il/org/osm/israelhiking/MainClass.java
@@ -50,8 +50,9 @@ public class MainClass {
                     "bbox");
             var supportedLanguages = args.getString("languages", "Languages to support", "en,he,ru,ar,es").split(",");
             var externalFilePath = args.getString("external-file-path", "External file path", "");
-            try (var context = ElasticsearchHelper.initRun(esClient, pointsIndexAlias, bboxIndexAlias,
-                    supportedLanguages)) {
+            var context = ElasticsearchHelper.initRun(esClient, pointsIndexAlias, bboxIndexAlias,
+                    supportedLanguages);
+            try (var bulkListener = context.bulkListener()) {
                 var profile = new PlanetSearchProfile(planetiler.config(), context);
 
                 String area = args.getString("area", "geofabrik area to download", "israel-and-palestine");

--- a/src/main/java/il/org/osm/israelhiking/MainClass.java
+++ b/src/main/java/il/org/osm/israelhiking/MainClass.java
@@ -43,42 +43,33 @@ public class MainClass {
         Planetiler planetiler = Planetiler.create(args);
 
         var esAddress = args.getString("es-address", "Elasticsearch address", "http://localhost:9200");
-        var esClient = ElasticsearchHelper.createElasticsearchClient(esAddress);
-        try {
+        try (var esClient = ElasticsearchHelper.createElasticsearchClient(esAddress)) {
             var pointsIndexAlias = args.getString("es-points-index-alias", "Elasticsearch index to populate points",
                     "points");
             var bboxIndexAlias = args.getString("es-bbox-index-alias", "Elasticsearch index to populate bounding boxes",
                     "bbox");
             var supportedLanguages = args.getString("languages", "Languages to support", "en,he,ru,ar,es").split(",");
             var externalFilePath = args.getString("external-file-path", "External file path", "");
-            var context = ElasticsearchHelper.initRun(esClient, pointsIndexAlias, bboxIndexAlias,
-                    supportedLanguages);
-            var profile = new PlanetSearchProfile(planetiler.config(), context);
+            try (var context = ElasticsearchHelper.initRun(esClient, pointsIndexAlias, bboxIndexAlias,
+                    supportedLanguages)) {
+                var profile = new PlanetSearchProfile(planetiler.config(), context);
 
-            String area = args.getString("area", "geofabrik area to download", "israel-and-palestine");
-            planetiler.setProfile(profile);
-            // override this default with osm_path="path/to/data.osm.pbf"
-            // Geofabrik has no whole-planet file, so area=planet uses the aws:latest
-            // s3://osm-pds mirror.
-            String osmSourceUrl = "planet".equals(area) ? "aws:latest" : "geofabrik:" + area;
-            planetiler.addOsmSource("osm", Path.of("data", "sources", area + ".osm.pbf"), osmSourceUrl);
-            if ("" != externalFilePath) {
-                planetiler.addGeoJsonSource("external", Path.of(externalFilePath));
-            }
-            planetiler.overwriteOutput(Path.of("data", "target", PlanetSearchProfile.POINTS_LAYER_NAME + ".pmtiles"));
+                String area = args.getString("area", "geofabrik area to download", "israel-and-palestine");
+                planetiler.setProfile(profile);
+                // override this default with osm_path="path/to/data.osm.pbf"
+                // Geofabrik has no whole-planet file, so area=planet uses the aws:latest
+                // s3://osm-pds mirror.
+                String osmSourceUrl = "planet".equals(area) ? "aws:latest" : "geofabrik:" + area;
+                planetiler.addOsmSource("osm", Path.of("data", "sources", area + ".osm.pbf"), osmSourceUrl);
+                if ("" != externalFilePath) {
+                    planetiler.addGeoJsonSource("external", Path.of(externalFilePath));
+                }
+                planetiler.overwriteOutput(
+                        Path.of("data", "target", PlanetSearchProfile.POINTS_LAYER_NAME + ".pmtiles"));
 
-            boolean finalized = false;
-            try {
                 planetiler.run();
                 ElasticsearchHelper.finalizeRun(context);
-                finalized = true;
-            } finally {
-                if (!finalized) {
-                    ElasticsearchHelper.abortRun(context);
-                }
             }
-        } finally {
-            esClient.close();
         }
     }
 }

--- a/src/main/java/il/org/osm/israelhiking/MainClass.java
+++ b/src/main/java/il/org/osm/israelhiking/MainClass.java
@@ -52,9 +52,17 @@ public class MainClass {
                 planetiler.addGeoJsonSource("external", Path.of(externalFilePath));
             }
             planetiler.overwriteOutput(Path.of("data", "target", PlanetSearchProfile.POINTS_LAYER_NAME + ".pmtiles"));
-            planetiler.run();
 
-            ElasticsearchHelper.finalizeRun(context);
+            boolean finalized = false;
+            try {
+                planetiler.run();
+                ElasticsearchHelper.finalizeRun(context);
+                finalized = true;
+            } finally {
+                if (!finalized) {
+                    ElasticsearchHelper.abortRun(context);
+                }
+            }
         } finally {
             esClient.close();
         }

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -640,7 +640,7 @@ public class PlanetSearchProfile implements Profile {
             .document(pointDocument))), docId);
   }
 
-  private void addToIngester(BulkOperation operation, String docId) {
+  void addToIngester(BulkOperation operation, String docId) {
     try {
       this.context.bulkIngester().add(operation);
       this.context.stats().emittedCount.increment();
@@ -651,16 +651,12 @@ public class PlanetSearchProfile implements Profile {
   }
 
   private void insertBboxToElasticsearch(SourceFeature feature, String[] supportedLanguages) {
-    Geometry polygon;
+    String bboxDocId = "<unknown>";
     try {
-      polygon = GeoUtils.worldToLatLonCoords(feature.polygon());
-    } catch (GeometryException e) {
-      return;
-    }
-    BBoxDocument bbox;
-    String bboxDocId;
-    try {
-      bbox = new BBoxDocument();
+      bboxDocId = sourceFeatureToDocumentId(feature);
+      final String docId = bboxDocId;
+      Geometry polygon = GeoUtils.worldToLatLonCoords(feature.polygon());
+      BBoxDocument bbox = new BBoxDocument();
       bbox.area = feature.areaMeters();
       var lngLatCenterPoint = GeoUtils.worldToLatLonCoords(feature.centroid()).getCoordinate();
       bbox.center = new double[] { lngLatCenterPoint.getX(), lngLatCenterPoint.getY() };
@@ -671,17 +667,16 @@ public class PlanetSearchProfile implements Profile {
       if (feature.hasTag("name")) {
         CoalesceIntoMap(bbox.name, "default", feature.getString("name"));
       }
-      bboxDocId = sourceFeatureToDocumentId(feature);
+      addToIngester(BulkOperation.of(op -> op
+          .index(idx -> idx
+              .index(this.context.bboxIndexTarget())
+              .id(docId)
+              .document(bbox))), docId);
     } catch (Exception e) {
-      LOGGER.warning(() -> "Failed to build bbox document: " + e.getMessage());
-      return;
+      this.context.stats().failedCount.increment();
+      final String failedId = bboxDocId;
+      LOGGER.warning(() -> "Failed to build bbox document " + failedId + ": " + e.getMessage());
     }
-    final BBoxDocument document = bbox;
-    addToIngester(BulkOperation.of(op -> op
-        .index(idx -> idx
-            .index(this.context.bboxIndexTarget())
-            .id(bboxDocId)
-            .document(document))), bboxDocId);
   }
 
   /**

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.math.NumberUtils;
@@ -27,9 +28,13 @@ import com.onthegomap.planetiler.reader.WithTags;
 import com.onthegomap.planetiler.reader.osm.OsmElement;
 import com.onthegomap.planetiler.reader.osm.OsmRelationInfo;
 
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+
 import il.org.osm.israelhiking.ElasticsearchHelper.ElasticRunContext;
 
 public class PlanetSearchProfile implements Profile {
+  private static final Logger LOGGER = Logger.getLogger(PlanetSearchProfile.class.getName());
+
   private PlanetilerConfig config;
   private ElasticRunContext context;
 
@@ -628,13 +633,20 @@ public class PlanetSearchProfile implements Profile {
   }
 
   private void insertPointToElasticsearch(PointDocument pointDocument, String docId) {
+    addToIngester(BulkOperation.of(op -> op
+        .index(idx -> idx
+            .index(this.context.pointsIndexTarget())
+            .id(docId)
+            .document(pointDocument))), docId);
+  }
+
+  private void addToIngester(BulkOperation operation, String docId) {
     try {
-      this.context.esClient().index(i -> i
-          .index(this.context.pointsIndexTarget())
-          .id(docId)
-          .document(pointDocument));
+      this.context.bulkIngester().add(operation);
+      this.context.stats().emittedCount.increment();
     } catch (Exception e) {
-      // swallow
+      this.context.stats().failedCount.increment();
+      LOGGER.warning(() -> "Failed to enqueue document " + docId + " for indexing: " + e.getMessage());
     }
   }
 
@@ -645,8 +657,10 @@ public class PlanetSearchProfile implements Profile {
     } catch (GeometryException e) {
       return;
     }
+    BBoxDocument bbox;
+    String bboxDocId;
     try {
-      var bbox = new BBoxDocument();
+      bbox = new BBoxDocument();
       bbox.area = feature.areaMeters();
       var lngLatCenterPoint = GeoUtils.worldToLatLonCoords(feature.centroid()).getCoordinate();
       bbox.center = new double[] { lngLatCenterPoint.getX(), lngLatCenterPoint.getY() };
@@ -657,13 +671,17 @@ public class PlanetSearchProfile implements Profile {
       if (feature.hasTag("name")) {
         CoalesceIntoMap(bbox.name, "default", feature.getString("name"));
       }
-      this.context.esClient().index(i -> i
-          .index(this.context.bboxIndexTarget())
-          .id(sourceFeatureToDocumentId(feature))
-          .document(bbox));
+      bboxDocId = sourceFeatureToDocumentId(feature);
     } catch (Exception e) {
-      // swallow
+      LOGGER.warning(() -> "Failed to build bbox document: " + e.getMessage());
+      return;
     }
+    final BBoxDocument document = bbox;
+    addToIngester(BulkOperation.of(op -> op
+        .index(idx -> idx
+            .index(this.context.bboxIndexTarget())
+            .id(bboxDocId)
+            .document(document))), bboxDocId);
   }
 
   /**

--- a/src/test/java/il/org/osm/israelhiking/BulkIngesterAccountingTest.java
+++ b/src/test/java/il/org/osm/israelhiking/BulkIngesterAccountingTest.java
@@ -34,7 +34,7 @@ class BulkIngesterAccountingTest {
     private LongAdder failedCount;
     private AccountingBulkListener listener;
 
-    private Logger profileLogger;
+    private Logger listenerLogger;
     private RecordingHandler handler;
     private Level previousLevel;
 
@@ -45,17 +45,17 @@ class BulkIngesterAccountingTest {
         failedCount = stats.failedCount;
         listener = new AccountingBulkListener(null, stats);
 
-        profileLogger = Logger.getLogger(PlanetSearchProfile.class.getName());
-        previousLevel = profileLogger.getLevel();
-        profileLogger.setLevel(Level.ALL);
+        listenerLogger = Logger.getLogger(AccountingBulkListener.class.getName());
+        previousLevel = listenerLogger.getLevel();
+        listenerLogger.setLevel(Level.ALL);
         handler = new RecordingHandler();
-        profileLogger.addHandler(handler);
+        listenerLogger.addHandler(handler);
     }
 
     @AfterEach
     void tearDown() {
-        profileLogger.removeHandler(handler);
-        profileLogger.setLevel(previousLevel);
+        listenerLogger.removeHandler(handler);
+        listenerLogger.setLevel(previousLevel);
     }
 
     @Test

--- a/src/test/java/il/org/osm/israelhiking/BulkIngesterAccountingTest.java
+++ b/src/test/java/il/org/osm/israelhiking/BulkIngesterAccountingTest.java
@@ -1,0 +1,221 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import co.elastic.clients.elasticsearch.core.bulk.OperationType;
+
+@Tag("unit")
+class BulkIngesterAccountingTest {
+
+    private static final String POINTS_INDEX = "points";
+
+    private IndexingStats stats;
+    private LongAdder indexedCount;
+    private LongAdder failedCount;
+    private AccountingBulkListener listener;
+
+    private Logger profileLogger;
+    private RecordingHandler handler;
+    private Level previousLevel;
+
+    @BeforeEach
+    void setUp() {
+        stats = new IndexingStats();
+        indexedCount = stats.indexedCount;
+        failedCount = stats.failedCount;
+        listener = new AccountingBulkListener(null, stats);
+
+        profileLogger = Logger.getLogger(PlanetSearchProfile.class.getName());
+        previousLevel = profileLogger.getLevel();
+        profileLogger.setLevel(Level.ALL);
+        handler = new RecordingHandler();
+        profileLogger.addHandler(handler);
+    }
+
+    @AfterEach
+    void tearDown() {
+        profileLogger.removeHandler(handler);
+        profileLogger.setLevel(previousLevel);
+    }
+
+    @Test
+    void afterBulk_withItemError_incrementsFailedCountAndLogsWarning() {
+        BulkResponseItem failedItem = item("bad-1", true);
+        BulkResponse response = responseWithErrors(List.of(failedItem));
+
+        listener.afterBulk(1L, emptyRequest(), Collections.emptyList(), response);
+
+        assertEquals(1, failedCount.sum(), "item with non-null error() must be counted as failed");
+        assertEquals(0, indexedCount.sum(), "a failed item must not be counted as indexed");
+        assertTrue(loggedAtLeast(Level.WARNING, "Failed to index id=bad-1"),
+                "the failure must be logged (surfaced), not swallowed");
+    }
+
+    @Test
+    void afterBulk_successPath_incrementsIndexedCount() {
+        BulkResponse response = BulkResponse.of(b -> b
+                .took(5)
+                .errors(false)
+                .items(List.of(item("ok-1", false), item("ok-2", false), item("ok-3", false))));
+
+        listener.afterBulk(2L, requestWithOperations(3), Collections.emptyList(), response);
+
+        assertEquals(3, indexedCount.sum());
+        assertEquals(0, failedCount.sum());
+    }
+
+    @Test
+    void afterBulk_mixedBatch_classifiesEachItemExactlyOnce() {
+        List<BulkResponseItem> items = List.of(
+                item("ok-1", false),
+                item("bad-1", true),
+                item("ok-2", false),
+                item("bad-2", true));
+        BulkResponse response = responseWithErrors(items);
+
+        listener.afterBulk(3L, requestWithOperations(items.size()), Collections.emptyList(), response);
+
+        assertEquals(2, indexedCount.sum());
+        assertEquals(2, failedCount.sum());
+    }
+
+    @Test
+    void losslessAccounting_indexedPlusFailedEqualsItemsSubmitted() {
+        int emitted = 10;
+        List<BulkResponseItem> items = new ArrayList<>();
+        for (int i = 0; i < emitted; i++) {
+            items.add(item("doc-" + i, i == 3 || i == 7));
+        }
+        BulkResponse response = responseWithErrors(items);
+
+        listener.afterBulk(4L, requestWithOperations(emitted), Collections.emptyList(), response);
+
+        long indexed = indexedCount.sum();
+        long failed = failedCount.sum();
+        assertEquals(8, indexed);
+        assertEquals(2, failed);
+        assertEquals(emitted, indexed + failed, "emitted must equal indexed + failed");
+    }
+
+    @Test
+    void afterBulk_wholeBatchNonRetryableThrowable_countsFailedAndLogsSevere() {
+        int batchSize = 7;
+        BulkRequest request = requestWithOperations(batchSize);
+
+        listener.afterBulk(5L, request, Collections.emptyList(),
+                new RuntimeException("malformed request"));
+
+        assertEquals(batchSize, failedCount.sum(),
+                "a non-retryable whole-batch failure must count every op as failed");
+        assertEquals(0, indexedCount.sum());
+        assertTrue(loggedAtLeast(Level.SEVERE, "failed non-retryably"),
+                "a non-retryable whole-batch error must be logged at SEVERE");
+    }
+
+    @Test
+    void indexingStats_gettersSumTheUnderlyingAdders() {
+        IndexingStats s = new IndexingStats();
+        assertEquals(0, s.getIndexedCount());
+        assertEquals(0, s.getFailedCount());
+        assertEquals(0, s.getEmittedCount());
+
+        s.indexedCount.add(7);
+        s.failedCount.add(3);
+        s.emittedCount.add(10);
+
+        assertEquals(7, s.getIndexedCount());
+        assertEquals(3, s.getFailedCount());
+        assertEquals(10, s.getEmittedCount(), "emitted is tracked independently of indexed/failed");
+    }
+
+    @Test
+    void afterBulk_nonRetryableThrowableWithNullMessage_stillCountsFailedAndDescribes() {
+        // A throwable with a null message exercises the null-message arm of describe(...)
+        // without an NPE; ops must still all be charged failed.
+        listener.afterBulk(9L, requestWithOperations(2), Collections.emptyList(),
+                new RuntimeException());
+
+        assertEquals(2, failedCount.sum());
+        assertEquals(0, indexedCount.sum());
+        assertTrue(loggedAtLeast(Level.SEVERE, "RuntimeException"),
+                "describe(...) must name the throwable class even when its message is null");
+    }
+
+    private static BulkResponse responseWithErrors(List<BulkResponseItem> items) {
+        return BulkResponse.of(b -> b.took(5).errors(true).items(items));
+    }
+
+    private static BulkResponseItem item(String id, boolean withError) {
+        return item(POINTS_INDEX, id, withError);
+    }
+
+    private static BulkResponseItem item(String index, String id, boolean withError) {
+        return BulkResponseItem.of(b -> {
+            b.operationType(OperationType.Index).index(index).id(id).status(withError ? 400 : 200);
+            if (withError) {
+                b.error(e -> e.type("mapper_parsing_exception").reason("bad doc " + id));
+            }
+            return b;
+        });
+    }
+
+    private static BulkRequest emptyRequest() {
+        // The BulkRequest builder requires a non-empty operations list.
+        return requestWithOperations(1);
+    }
+
+    private static BulkRequest requestWithOperations(int n) {
+        List<BulkOperation> ops = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            final int idx = i;
+            ops.add(BulkOperation.of(op -> op.index(ix -> ix.index(POINTS_INDEX).id("op-" + idx).document(Map.of("k", idx)))));
+        }
+        return BulkRequest.of(b -> b.operations(ops));
+    }
+
+    private boolean loggedAtLeast(Level level, String substring) {
+        return handler.records.stream()
+                .anyMatch(r -> r.getLevel() == level && formatted(r).contains(substring));
+    }
+
+    private static String formatted(LogRecord r) {
+        return r.getMessage() == null ? "" : r.getMessage();
+    }
+
+    private static final class RecordingHandler extends Handler {
+        private final List<LogRecord> records = Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/BulkIngesterAccountingTest.java
+++ b/src/test/java/il/org/osm/israelhiking/BulkIngesterAccountingTest.java
@@ -150,8 +150,6 @@ class BulkIngesterAccountingTest {
 
     @Test
     void afterBulk_nonRetryableThrowableWithNullMessage_stillCountsFailedAndDescribes() {
-        // A throwable with a null message exercises the null-message arm of describe(...)
-        // without an NPE; ops must still all be charged failed.
         listener.afterBulk(9L, requestWithOperations(2), Collections.emptyList(),
                 new RuntimeException());
 
@@ -180,7 +178,6 @@ class BulkIngesterAccountingTest {
     }
 
     private static BulkRequest emptyRequest() {
-        // The BulkRequest builder requires a non-empty operations list.
         return requestWithOperations(1);
     }
 

--- a/src/test/java/il/org/osm/israelhiking/DefensiveCatchCoverageTest.java
+++ b/src/test/java/il/org/osm/israelhiking/DefensiveCatchCoverageTest.java
@@ -2,14 +2,12 @@ package il.org.osm.israelhiking;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -79,40 +77,33 @@ class DefensiveCatchCoverageTest {
     }
 
     @Test
-    void contextClose_whenIngesterCloseThrows_swallows_andStillAwaitsRetries() {
+    void listenerClose_whenIngesterCloseThrows_swallows_andStillDrainsRetries() {
         @SuppressWarnings("unchecked")
         BulkIngester<Void> ingester = mock(BulkIngester.class);
         doThrow(new IllegalStateException("close failed")).when(ingester).close();
 
-        AccountingBulkListener listener = mock(AccountingBulkListener.class);
-        when(listener.tryClaimIngesterClose()).thenReturn(true);
+        AccountingBulkListener listener = new AccountingBulkListener(null, stats);
+        listener.attachIngester(ingester);
 
-        ElasticRunContext context = new ElasticRunContext(
-                null, "points", "bbox", "points1", "bbox1",
-                new String[] { "he" }, ingester, listener, stats);
-
-        assertDoesNotThrow(context::close,
+        assertDoesNotThrow(listener::close,
                 "abort must not let a close() failure mask the original build error");
 
         verify(ingester).close();
-        verify(listener).awaitRetries();
+        assertTrue(listener.isDrained(), "retries must still drain even when ingester close throws");
     }
 
     @Test
-    void finalizeThenAutoClose_doesNotCloseIngesterTwice() {
+    void listenerClose_calledTwice_closesIngesterOnce_andDrains() {
         @SuppressWarnings("unchecked")
         BulkIngester<Void> ingester = mock(BulkIngester.class);
         AccountingBulkListener listener = new AccountingBulkListener(null, stats);
+        listener.attachIngester(ingester);
 
-        ElasticRunContext context = new ElasticRunContext(
-                null, "points", "bbox", "points1", "bbox1",
-                new String[] { "he" }, ingester, listener, stats);
+        listener.close();
+        listener.close();
 
-        assertTrue(listener.tryClaimIngesterClose(), "finalizeRun claims the close first");
-        context.close();
-
-        assertFalse(listener.tryClaimIngesterClose(), "the claim is one-shot across finalizeRun + close()");
-        verify(ingester, times(0)).close();
+        verify(ingester, times(1)).close();
+        assertTrue(listener.isDrained(), "close() must drain retries");
     }
 
     private boolean loggedAtLeast(Level level, String substring) {

--- a/src/test/java/il/org/osm/israelhiking/DefensiveCatchCoverageTest.java
+++ b/src/test/java/il/org/osm/israelhiking/DefensiveCatchCoverageTest.java
@@ -2,11 +2,14 @@ package il.org.osm.israelhiking;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -82,6 +85,7 @@ class DefensiveCatchCoverageTest {
         doThrow(new IllegalStateException("close failed")).when(ingester).close();
 
         AccountingBulkListener listener = mock(AccountingBulkListener.class);
+        when(listener.tryClaimIngesterClose()).thenReturn(true);
 
         ElasticRunContext context = new ElasticRunContext(
                 null, "points", "bbox", "points1", "bbox1",
@@ -92,6 +96,23 @@ class DefensiveCatchCoverageTest {
 
         verify(ingester).close();
         verify(listener).awaitRetries();
+    }
+
+    @Test
+    void finalizeThenAutoClose_doesNotCloseIngesterTwice() {
+        @SuppressWarnings("unchecked")
+        BulkIngester<Void> ingester = mock(BulkIngester.class);
+        AccountingBulkListener listener = new AccountingBulkListener(null, stats);
+
+        ElasticRunContext context = new ElasticRunContext(
+                null, "points", "bbox", "points1", "bbox1",
+                new String[] { "he" }, ingester, listener, stats);
+
+        assertTrue(listener.tryClaimIngesterClose(), "finalizeRun claims the close first");
+        context.close();
+
+        assertFalse(listener.tryClaimIngesterClose(), "the claim is one-shot across finalizeRun + close()");
+        verify(ingester, times(0)).close();
     }
 
     private boolean loggedAtLeast(Level level, String substring) {

--- a/src/test/java/il/org/osm/israelhiking/DefensiveCatchCoverageTest.java
+++ b/src/test/java/il/org/osm/israelhiking/DefensiveCatchCoverageTest.java
@@ -1,0 +1,119 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import co.elastic.clients.elasticsearch._helpers.bulk.BulkIngester;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+
+import il.org.osm.israelhiking.ElasticsearchHelper.ElasticRunContext;
+
+@Tag("unit")
+class DefensiveCatchCoverageTest {
+
+    private IndexingStats stats;
+    private Logger profileLogger;
+    private RecordingHandler profileHandler;
+    private Level prevProfileLevel;
+
+    @BeforeEach
+    void setUp() {
+        stats = new IndexingStats();
+        profileLogger = Logger.getLogger(PlanetSearchProfile.class.getName());
+        prevProfileLevel = profileLogger.getLevel();
+        profileLogger.setLevel(Level.ALL);
+        profileHandler = new RecordingHandler();
+        profileLogger.addHandler(profileHandler);
+    }
+
+    @AfterEach
+    void tearDown() {
+        profileLogger.removeHandler(profileHandler);
+        profileLogger.setLevel(prevProfileLevel);
+    }
+
+    @Test
+    void addToIngester_whenEnqueueThrows_countsFailed_logsWarning_doesNotRethrow() {
+        @SuppressWarnings("unchecked")
+        BulkIngester<Void> ingester = mock(BulkIngester.class);
+        doThrow(new IllegalStateException("Ingester is already closed"))
+                .when(ingester).add(any(BulkOperation.class));
+
+        ElasticRunContext context = new ElasticRunContext(
+                null, "points", "bbox", "points1", "bbox1",
+                new String[] { "he" }, ingester, null, stats);
+        PlanetSearchProfile profile = new PlanetSearchProfile(null, context);
+
+        BulkOperation op = BulkOperation.of(o -> o
+                .index(ix -> ix.index("points1").id("doc-1").document(Map.of("k", 1))));
+
+        assertDoesNotThrow(() -> profile.addToIngester(op, "doc-1"),
+                "a closed/failed ingester must not abort the build");
+
+        assertEquals(1, stats.failedCount.sum(), "a dropped enqueue must be charged failed");
+        assertEquals(0, stats.emittedCount.sum(), "a failed enqueue must not be counted emitted");
+        assertTrue(loggedAtLeast(Level.WARNING, "Failed to enqueue document doc-1"),
+                "the dropped document must be surfaced in the log, not swallowed silently");
+    }
+
+    @Test
+    void contextClose_whenIngesterCloseThrows_swallows_andStillAwaitsRetries() {
+        @SuppressWarnings("unchecked")
+        BulkIngester<Void> ingester = mock(BulkIngester.class);
+        doThrow(new IllegalStateException("close failed")).when(ingester).close();
+
+        AccountingBulkListener listener = mock(AccountingBulkListener.class);
+
+        ElasticRunContext context = new ElasticRunContext(
+                null, "points", "bbox", "points1", "bbox1",
+                new String[] { "he" }, ingester, listener, stats);
+
+        assertDoesNotThrow(context::close,
+                "abort must not let a close() failure mask the original build error");
+
+        verify(ingester).close();
+        verify(listener).awaitRetries();
+    }
+
+    private boolean loggedAtLeast(Level level, String substring) {
+        return profileHandler.records.stream()
+                .anyMatch(r -> r.getLevel() == level
+                        && r.getMessage() != null && r.getMessage().contains(substring));
+    }
+
+    private static final class RecordingHandler extends Handler {
+        private final List<LogRecord> records = Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/IndexerResilienceTest.java
+++ b/src/test/java/il/org/osm/israelhiking/IndexerResilienceTest.java
@@ -20,8 +20,8 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -42,23 +42,9 @@ class IndexerResilienceTest {
 
     private IndexingStats stats;
 
-    private long origBase;
-    private long origMax;
-
     @BeforeEach
     void setUp() {
         stats = new IndexingStats();
-        // Zero the backoff so the retry loop runs instantly.
-        origBase = AccountingBulkListener.BASE_BACKOFF_MILLIS;
-        origMax = AccountingBulkListener.MAX_BACKOFF_MILLIS;
-        AccountingBulkListener.BASE_BACKOFF_MILLIS = 0L;
-        AccountingBulkListener.MAX_BACKOFF_MILLIS = 0L;
-    }
-
-    @AfterEach
-    void tearDown() {
-        AccountingBulkListener.BASE_BACKOFF_MILLIS = origBase;
-        AccountingBulkListener.MAX_BACKOFF_MILLIS = origMax;
     }
 
     private long indexed() {
@@ -95,7 +81,7 @@ class IndexerResilienceTest {
     }
 
     private AccountingBulkListener driveRetryViaAfterBulk(ElasticsearchClient client, int opCount, Throwable wholeBatchFailure) {
-        AccountingBulkListener listener = new AccountingBulkListener(client, stats);
+        AccountingBulkListener listener = new AccountingBulkListener(client, stats, 0L, 0L);
         listener.afterBulk(1L, requestOf(operations(opCount)), List.of(), wholeBatchFailure);
         listener.awaitRetries();
         return listener;
@@ -165,28 +151,18 @@ class IndexerResilienceTest {
 
     @Test
     void backoff_isExponentialBoundedAndCapped() {
-        // backoffMillis reads the (here zeroed) tuning constants, so set production values.
-        long savedBase = AccountingBulkListener.BASE_BACKOFF_MILLIS;
-        long savedMax = AccountingBulkListener.MAX_BACKOFF_MILLIS;
-        AccountingBulkListener.BASE_BACKOFF_MILLIS = 1_000L;
-        AccountingBulkListener.MAX_BACKOFF_MILLIS = 16_000L;
-        try {
-            assertWithinJitter(1, 1_000);
-            assertWithinJitter(2, 2_000);
-            assertWithinJitter(3, 4_000);
-            assertWithinJitter(4, 8_000);
-            assertWithinJitter(5, 16_000);
-            assertWithinJitter(6, 16_000);
-            assertWithinJitter(10, 16_000);
-        } finally {
-            AccountingBulkListener.BASE_BACKOFF_MILLIS = savedBase;
-            AccountingBulkListener.MAX_BACKOFF_MILLIS = savedMax;
-        }
+        assertWithinJitter(1, 1_000);
+        assertWithinJitter(2, 2_000);
+        assertWithinJitter(3, 4_000);
+        assertWithinJitter(4, 8_000);
+        assertWithinJitter(5, 16_000);
+        assertWithinJitter(6, 16_000);
+        assertWithinJitter(10, 16_000);
     }
 
     private static void assertWithinJitter(int attempt, long cap) {
         for (int i = 0; i < 200; i++) {
-            long b = AccountingBulkListener.backoffMillis(attempt);
+            long b = AccountingBulkListener.backoffMillis(attempt, 1_000L, 16_000L);
             assertTrue(b >= cap / 2 && b <= cap,
                     "attempt " + attempt + " backoff " + b + " out of [" + (cap / 2) + "," + cap + "]");
         }
@@ -310,7 +286,7 @@ class IndexerResilienceTest {
                 item("op-0", 200, false),
                 item("op-1", 200, false))));
         ElasticsearchClient client = mockClient(shortOk, successResponse(1));
-        AccountingBulkListener listener = new AccountingBulkListener(client, stats);
+        AccountingBulkListener listener = new AccountingBulkListener(client, stats, 0L, 0L);
 
         listener.afterBulk(1L, requestOf(operations(3)), List.of(), shortOk);
         listener.awaitRetries();
@@ -327,7 +303,7 @@ class IndexerResilienceTest {
                 item("op-0", 200, false),
                 item("op-1", 503, true))));
         ElasticsearchClient client = mockClient(successResponse(1));
-        AccountingBulkListener listener = new AccountingBulkListener(client, stats);
+        AccountingBulkListener listener = new AccountingBulkListener(client, stats, 0L, 0L);
 
         listener.afterBulk(1L, requestOf(operations(2)), List.of(), first);
         listener.awaitRetries();
@@ -383,5 +359,39 @@ class IndexerResilienceTest {
 
     private static co.elastic.clients.elasticsearch.core.BulkRequest requestOf(List<BulkOperation> ops) {
         return co.elastic.clients.elasticsearch.core.BulkRequest.of(b -> b.operations(ops));
+    }
+
+    @Test
+    void drainTimeout_forcedShutdown_chargesEveryRetryOpAsFailed() throws InterruptedException {
+        CountDownLatch release = new CountDownLatch(1);
+        ElasticsearchClient blocking = mock(ElasticsearchClient.class);
+        try {
+            when(blocking.bulk(any(BulkRequest.class))).thenAnswer(inv -> {
+                release.await();
+                return successResponse(1);
+            });
+        } catch (IOException impossible) {
+            throw new AssertionError(impossible);
+        }
+
+        AccountingBulkListener listener = new AccountingBulkListener(blocking, stats, 0L, 0L, 0L);
+        int queuedBatches = 2;
+        int batches = AccountingBulkListener.RETRY_POOL_SIZE + queuedBatches;
+        for (int i = 0; i < batches; i++) {
+            listener.afterBulk(i, requestOf(operations(2)), List.of(), new SocketTimeoutException("timeout"));
+        }
+
+        listener.awaitRetries();
+        assertTrue(failed() >= 2L * queuedBatches,
+                "chargeDropped must charge the queued-never-started batches synchronously on forced shutdown");
+        release.countDown();
+
+        long total = 2L * batches;
+        for (int i = 0; i < 500 && failed() < total; i++) {
+            Thread.sleep(5);
+        }
+        assertEquals(total, failed(),
+                "every retry op — dropped-queued and interrupted-running — is charged failed; none vanish");
+        assertEquals(0, indexed());
     }
 }

--- a/src/test/java/il/org/osm/israelhiking/IndexerResilienceTest.java
+++ b/src/test/java/il/org/osm/israelhiking/IndexerResilienceTest.java
@@ -1,0 +1,387 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+
+import org.apache.http.StatusLine;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import co.elastic.clients.elasticsearch.core.bulk.OperationType;
+
+@Tag("unit")
+class IndexerResilienceTest {
+
+    private static final String POINTS_INDEX = "points";
+
+    private IndexingStats stats;
+
+    private long origBase;
+    private long origMax;
+
+    @BeforeEach
+    void setUp() {
+        stats = new IndexingStats();
+        // Zero the backoff so the retry loop runs instantly.
+        origBase = AccountingBulkListener.BASE_BACKOFF_MILLIS;
+        origMax = AccountingBulkListener.MAX_BACKOFF_MILLIS;
+        AccountingBulkListener.BASE_BACKOFF_MILLIS = 0L;
+        AccountingBulkListener.MAX_BACKOFF_MILLIS = 0L;
+    }
+
+    @AfterEach
+    void tearDown() {
+        AccountingBulkListener.BASE_BACKOFF_MILLIS = origBase;
+        AccountingBulkListener.MAX_BACKOFF_MILLIS = origMax;
+    }
+
+    private long indexed() {
+        return stats.indexedCount.sum();
+    }
+
+    private long failed() {
+        return stats.failedCount.sum();
+    }
+
+    // Replays scripted responses/throwables in order, repeating the last once exhausted.
+    private static ElasticsearchClient mockClient(Object... script) {
+        ElasticsearchClient client = mock(ElasticsearchClient.class);
+        Deque<Object> queue = new ArrayDeque<>(List.of(script));
+        Answer<BulkResponse> answer = invocation -> {
+            Object next = queue.size() > 1 ? queue.poll() : queue.peek();
+            if (next instanceof Throwable t) {
+                if (t instanceof RuntimeException re) {
+                    throw re;
+                }
+                if (t instanceof Exception e) {
+                    throw e;
+                }
+                throw new RuntimeException(t);
+            }
+            return (BulkResponse) next;
+        };
+        try {
+            when(client.bulk(any(BulkRequest.class))).thenAnswer(answer);
+        } catch (IOException impossible) {
+            throw new AssertionError(impossible);
+        }
+        return client;
+    }
+
+    private AccountingBulkListener driveRetryViaAfterBulk(ElasticsearchClient client, int opCount, Throwable wholeBatchFailure) {
+        AccountingBulkListener listener = new AccountingBulkListener(client, stats);
+        listener.afterBulk(1L, requestOf(operations(opCount)), List.of(), wholeBatchFailure);
+        listener.awaitRetries();
+        return listener;
+    }
+
+    @Test
+    void classification_transientTransportErrorsAreRetryable() {
+        assertTrue(AccountingBulkListener.isRetryable(
+                new SocketTimeoutException("30,000 milliseconds timeout on connection")));
+        assertTrue(AccountingBulkListener.isRetryable(new ConnectException("refused")));
+        assertTrue(AccountingBulkListener.isRetryable(new IOException("connection reset")));
+        assertTrue(AccountingBulkListener.isRetryable(
+                new RuntimeException("wrapped", new SocketTimeoutException("timeout"))));
+    }
+
+    @Test
+    void classification_4xxAndPlainRuntimeAreNotRetryable() {
+        assertFalse(AccountingBulkListener.isRetryable(new RuntimeException("bad request")));
+        assertTrue(AccountingBulkListener.isRetryableStatus(429));
+        assertTrue(AccountingBulkListener.isRetryableStatus(502));
+        assertTrue(AccountingBulkListener.isRetryableStatus(503));
+        assertTrue(AccountingBulkListener.isRetryableStatus(504));
+        assertFalse(AccountingBulkListener.isRetryableStatus(400));
+        assertFalse(AccountingBulkListener.isRetryableStatus(404));
+    }
+
+    @Test
+    void classification_connectTimeoutException_isRetryable() {
+        // org.apache.http.conn.ConnectTimeoutException is a distinct cause-chain arm from
+        // SocketTimeoutException/ConnectException; cover it directly (nested too).
+        assertTrue(AccountingBulkListener.isRetryable(new ConnectTimeoutException("connect timed out")));
+        assertTrue(AccountingBulkListener.isRetryable(
+                new RuntimeException("wrapped", new ConnectTimeoutException("connect timed out"))));
+    }
+
+    @Test
+    void classification_responseException_retryableVsNonRetryableStatus() {
+        // ResponseException is final and reads its Response in the ctor, so mock the chain
+        // it walks: getResponse().getStatusLine().getStatusCode().
+        assertTrue(AccountingBulkListener.isRetryable(responseException(503)),
+                "a 503 ResponseException is retryable");
+        assertFalse(AccountingBulkListener.isRetryable(responseException(400)),
+                "a 400 ResponseException is not retryable");
+    }
+
+    @Test
+    void classification_elasticsearchExceptionStatus_isHonored() {
+        assertTrue(AccountingBulkListener.isRetryable(
+                new ElasticsearchException("bulk", errorResponse(429))));
+        assertFalse(AccountingBulkListener.isRetryable(
+                new ElasticsearchException("bulk", errorResponse(404))));
+    }
+
+    @Test
+    void classification_selfReferentialCause_doesNotLoopAndIsNotRetryable() {
+        // A throwable whose cause is itself must terminate the walk via the guard and
+        // fall through to non-retryable rather than spin forever. The JDK forbids
+        // initCause(this), so override getCause() to return the instance.
+        RuntimeException loop = new RuntimeException("self") {
+            @Override
+            public synchronized Throwable getCause() {
+                return this;
+            }
+        };
+        assertFalse(AccountingBulkListener.isRetryable(loop));
+    }
+
+    @Test
+    void backoff_isExponentialBoundedAndCapped() {
+        // backoffMillis reads the (here zeroed) tuning constants, so set production values.
+        long savedBase = AccountingBulkListener.BASE_BACKOFF_MILLIS;
+        long savedMax = AccountingBulkListener.MAX_BACKOFF_MILLIS;
+        AccountingBulkListener.BASE_BACKOFF_MILLIS = 1_000L;
+        AccountingBulkListener.MAX_BACKOFF_MILLIS = 16_000L;
+        try {
+            assertWithinJitter(1, 1_000);
+            assertWithinJitter(2, 2_000);
+            assertWithinJitter(3, 4_000);
+            assertWithinJitter(4, 8_000);
+            assertWithinJitter(5, 16_000);
+            assertWithinJitter(6, 16_000);
+            assertWithinJitter(10, 16_000);
+        } finally {
+            AccountingBulkListener.BASE_BACKOFF_MILLIS = savedBase;
+            AccountingBulkListener.MAX_BACKOFF_MILLIS = savedMax;
+        }
+    }
+
+    private static void assertWithinJitter(int attempt, long cap) {
+        for (int i = 0; i < 200; i++) {
+            long b = AccountingBulkListener.backoffMillis(attempt);
+            assertTrue(b >= cap / 2 && b <= cap,
+                    "attempt " + attempt + " backoff " + b + " out of [" + (cap / 2) + "," + cap + "]");
+        }
+    }
+
+    @Test
+    void retry_recoversOnSecondAttempt_countsIndexed_noFailures() {
+        ElasticsearchClient client = mockClient(new SocketTimeoutException("timeout"), successResponse(3));
+
+        driveRetryViaAfterBulk(client, 3, new SocketTimeoutException("timeout"));
+
+        assertEquals(3, indexed(), "recovered ops are counted as indexed");
+        assertEquals(0, failed());
+    }
+
+    @Test
+    void retry_perItem4xxIsCountedFailed_andNotRetried() {
+        BulkResponse mixed = BulkResponse.of(b -> b.took(1).errors(true).items(List.of(
+                item("op-0", 200, false),
+                item("op-1", 400, true),
+                item("op-2", 200, false))));
+        ElasticsearchClient client = mockClient(mixed);
+
+        driveRetryViaAfterBulk(client, 3, new SocketTimeoutException("timeout"));
+
+        assertEquals(2, indexed());
+        assertEquals(1, failed(), "a 400 per-item error is counted as failed");
+    }
+
+    @Test
+    void retry_exhausted_countsFailed() {
+        ElasticsearchClient client = mockClient(new SocketTimeoutException("timeout"));
+
+        driveRetryViaAfterBulk(client, 4, new SocketTimeoutException("timeout"));
+
+        assertEquals(0, indexed());
+        assertEquals(4, failed(), "exhausted ops are counted as failed");
+    }
+
+    @Test
+    void retry_partialRetryableItems_areRetriedThenCountedFailed() {
+        BulkResponse firstAttempt = BulkResponse.of(b -> b.took(1).errors(true).items(List.of(
+                item("op-0", 200, false),
+                item("op-1", 503, true))));
+        BulkResponse stillFailing = BulkResponse.of(b -> b.took(1).errors(true).items(List.of(
+                item("op-1", 503, true))));
+        ElasticsearchClient client = mockClient(firstAttempt, stillFailing);
+
+        driveRetryViaAfterBulk(client, 2, new SocketTimeoutException("timeout"));
+
+        assertEquals(1, indexed(), "the op that succeeded on attempt 1 is counted once");
+        assertEquals(1, failed(), "the persistently-503 op is counted failed after retries");
+    }
+
+    @Test
+    void retry_shortResponse_doesNotSilentlyDropSurplusOps() {
+        BulkResponse shortOk = BulkResponse.of(b -> b.took(1).errors(false).items(List.of(
+                item("op-0", 200, false),
+                item("op-1", 200, false))));
+        ElasticsearchClient client = mockClient(shortOk, successResponse(1));
+
+        driveRetryViaAfterBulk(client, 3, new SocketTimeoutException("timeout"));
+
+        assertEquals(3, indexed(), "the surplus op is retried and indexed, not dropped");
+        assertEquals(0, failed());
+    }
+
+    @Test
+    void retry_nonRetryableExceptionDuringResubmit_countsFailed_andStops() {
+        ElasticsearchClient client = mockClient(new RuntimeException("400 illegal_argument_exception"));
+
+        driveRetryViaAfterBulk(client, 3, new SocketTimeoutException("timeout"));
+
+        assertEquals(3, failed(), "a non-retryable resubmit error counts ops as failed");
+        assertEquals(0, indexed());
+    }
+
+    @Test
+    void retryablePerItemStatus_isRetried_thenRecovers_notCountedFailed() {
+        BulkResponse first503 = BulkResponse.of(b -> b.took(1).errors(true).items(List.of(
+                item("op-0", 503, true))));
+        ElasticsearchClient client = mockClient(first503, successResponse(1));
+
+        driveRetryViaAfterBulk(client, 1, new SocketTimeoutException("timeout"));
+
+        assertEquals(1, indexed(), "the 503 op recovers on resubmit");
+        assertEquals(0, failed(), "a 503 is retryable, never charged failed when it recovers");
+    }
+
+    @Test
+    void wholeBatchNonRetryableThrowable_isNotRetried_countsFailed() {
+        AccountingBulkListener listener = new AccountingBulkListener(mock(ElasticsearchClient.class), stats);
+
+        listener.afterBulk(6L, requestOf(operations(2)), List.of(),
+                new ElasticsearchException("bulk", errorResponse(400)));
+        listener.awaitRetries();
+
+        assertEquals(2, failed());
+        assertEquals(0, indexed());
+    }
+
+    @Test
+    void initialResponse_perItem4xxIsCountedFailed() {
+        AccountingBulkListener listener = new AccountingBulkListener(null, stats);
+        BulkResponse mixed = BulkResponse.of(b -> b.took(1).errors(true).items(List.of(
+                item("op-0", 200, false),
+                item("op-1", 400, true),
+                item("op-2", 200, false))));
+
+        listener.afterBulk(1L, requestOf(operations(3)), List.of(), mixed);
+
+        assertEquals(2, indexed());
+        assertEquals(1, failed(), "a 400 per-item error is counted as failed");
+    }
+
+    @Test
+    void initialResponse_shortButErrorFree_doesNotTakeFastPath_andRetriesSurplus() {
+        // !errors() but items.size() < operations.size(): the fast path must be skipped so
+        // the missing op is classified (retried), not silently counted.
+        BulkResponse shortOk = BulkResponse.of(b -> b.took(1).errors(false).items(List.of(
+                item("op-0", 200, false),
+                item("op-1", 200, false))));
+        ElasticsearchClient client = mockClient(shortOk, successResponse(1));
+        AccountingBulkListener listener = new AccountingBulkListener(client, stats);
+
+        listener.afterBulk(1L, requestOf(operations(3)), List.of(), shortOk);
+        listener.awaitRetries();
+
+        assertEquals(3, indexed(), "the op missing from the short response is retried and indexed");
+        assertEquals(0, failed());
+    }
+
+    @Test
+    void initialResponse_retryablePerItem_offloadsRetry_thenRecovers() {
+        // A retryable (503) per-item on the FIRST response must drive offloadRetry from the
+        // success-overload afterBulk, not just from the throwable overload.
+        BulkResponse first = BulkResponse.of(b -> b.took(1).errors(true).items(List.of(
+                item("op-0", 200, false),
+                item("op-1", 503, true))));
+        ElasticsearchClient client = mockClient(successResponse(1));
+        AccountingBulkListener listener = new AccountingBulkListener(client, stats);
+
+        listener.afterBulk(1L, requestOf(operations(2)), List.of(), first);
+        listener.awaitRetries();
+
+        assertEquals(2, indexed(), "op-0 indexed immediately, op-1 recovers on retry");
+        assertEquals(0, failed());
+    }
+
+    private static BulkResponse successResponse(int n) {
+        List<BulkResponseItem> items = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            items.add(item("op-" + i, 200, false));
+        }
+        return BulkResponse.of(b -> b.took(1).errors(false).items(items));
+    }
+
+    private static BulkResponseItem item(String id, int status, boolean withError) {
+        return BulkResponseItem.of(b -> {
+            b.operationType(OperationType.Index).index(POINTS_INDEX).id(id).status(status);
+            if (withError) {
+                b.error(e -> e.type("mapper_parsing_exception").reason("err " + id));
+            }
+            return b;
+        });
+    }
+
+    // ResponseException is final and its real ctor reads the Response body; mock only the
+    // accessor chain isRetryable walks.
+    private static ResponseException responseException(int status) {
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(status);
+        Response response = mock(Response.class);
+        when(response.getStatusLine()).thenReturn(statusLine);
+        ResponseException re = mock(ResponseException.class);
+        when(re.getResponse()).thenReturn(response);
+        return re;
+    }
+
+    private static co.elastic.clients.elasticsearch._types.ErrorResponse errorResponse(int status) {
+        return co.elastic.clients.elasticsearch._types.ErrorResponse.of(b -> b
+                .status(status)
+                .error(e -> e.type("illegal_argument_exception").reason("bad request")));
+    }
+
+    private static List<BulkOperation> operations(int n) {
+        List<BulkOperation> ops = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            final int idx = i;
+            ops.add(BulkOperation.of(op -> op.index(ix -> ix.index(POINTS_INDEX).id("op-" + idx).document(Map.of("k", idx)))));
+        }
+        return ops;
+    }
+
+    private static co.elastic.clients.elasticsearch.core.BulkRequest requestOf(List<BulkOperation> ops) {
+        return co.elastic.clients.elasticsearch.core.BulkRequest.of(b -> b.operations(ops));
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/IndexerResilienceTest.java
+++ b/src/test/java/il/org/osm/israelhiking/IndexerResilienceTest.java
@@ -55,7 +55,6 @@ class IndexerResilienceTest {
         return stats.failedCount.sum();
     }
 
-    // Replays scripted responses/throwables in order, repeating the last once exhausted.
     private static ElasticsearchClient mockClient(Object... script) {
         ElasticsearchClient client = mock(ElasticsearchClient.class);
         Deque<Object> queue = new ArrayDeque<>(List.of(script));
@@ -110,8 +109,6 @@ class IndexerResilienceTest {
 
     @Test
     void classification_connectTimeoutException_isRetryable() {
-        // org.apache.http.conn.ConnectTimeoutException is a distinct cause-chain arm from
-        // SocketTimeoutException/ConnectException; cover it directly (nested too).
         assertTrue(AccountingBulkListener.isRetryable(new ConnectTimeoutException("connect timed out")));
         assertTrue(AccountingBulkListener.isRetryable(
                 new RuntimeException("wrapped", new ConnectTimeoutException("connect timed out"))));
@@ -119,8 +116,6 @@ class IndexerResilienceTest {
 
     @Test
     void classification_responseException_retryableVsNonRetryableStatus() {
-        // ResponseException is final and reads its Response in the ctor, so mock the chain
-        // it walks: getResponse().getStatusLine().getStatusCode().
         assertTrue(AccountingBulkListener.isRetryable(responseException(503)),
                 "a 503 ResponseException is retryable");
         assertFalse(AccountingBulkListener.isRetryable(responseException(400)),
@@ -137,9 +132,6 @@ class IndexerResilienceTest {
 
     @Test
     void classification_selfReferentialCause_doesNotLoopAndIsNotRetryable() {
-        // A throwable whose cause is itself must terminate the walk via the guard and
-        // fall through to non-retryable rather than spin forever. The JDK forbids
-        // initCause(this), so override getCause() to return the instance.
         RuntimeException loop = new RuntimeException("self") {
             @Override
             public synchronized Throwable getCause() {
@@ -280,8 +272,6 @@ class IndexerResilienceTest {
 
     @Test
     void initialResponse_shortButErrorFree_doesNotTakeFastPath_andRetriesSurplus() {
-        // !errors() but items.size() < operations.size(): the fast path must be skipped so
-        // the missing op is classified (retried), not silently counted.
         BulkResponse shortOk = BulkResponse.of(b -> b.took(1).errors(false).items(List.of(
                 item("op-0", 200, false),
                 item("op-1", 200, false))));
@@ -297,8 +287,6 @@ class IndexerResilienceTest {
 
     @Test
     void initialResponse_retryablePerItem_offloadsRetry_thenRecovers() {
-        // A retryable (503) per-item on the FIRST response must drive offloadRetry from the
-        // success-overload afterBulk, not just from the throwable overload.
         BulkResponse first = BulkResponse.of(b -> b.took(1).errors(true).items(List.of(
                 item("op-0", 200, false),
                 item("op-1", 503, true))));
@@ -330,8 +318,6 @@ class IndexerResilienceTest {
         });
     }
 
-    // ResponseException is final and its real ctor reads the Response body; mock only the
-    // accessor chain isRetryable walks.
     private static ResponseException responseException(int status) {
         StatusLine statusLine = mock(StatusLine.class);
         when(statusLine.getStatusCode()).thenReturn(status);


### PR DESCRIPTION
## What

The indexer fire-and-forgot each `esClient.index()` call and swallowed every error, so any document that failed to index silently disappeared from search. This is the root cause behind missing results.

## Change

Point and bbox insertion now go through a `BulkIngester` whose listener (`AccountingBulkListener`) counts every outcome and surfaces failures instead of swallowing them:

- Transient transport errors (429/5xx, timeouts) are retried with exponential backoff and jitter; per-item 4xx (mapping/parse) are charged as genuine failures and never retried.
- The ingester, listener and counters are owned by the run context in `ElasticsearchHelper` (built in `initRun`, drained and closed in `finalizeRun` before the alias swap). The profile only adds documents to the injected ingester.
- `finalizeRun` logs one summary line (emitted/indexed/failed). There is no promotion gate; a mismatch is reported in that line, not fail-closed.
- `abortRun` releases the ingester and retry threads if the build throws, so they cannot leak (no alias is swapped in that case).

## Tests

`BulkIngesterAccountingTest` and `IndexerResilienceTest` are pure unit tests (Mockito, no live cluster). The retry state machine is exercised through the real `afterBulk(...)` path with a mocked client, so there is no test-only seam in production code. `mvn test` passes.

Non-breaking and independent of the other split PRs.

## Review notes addressed (from #63)

- Inject the bulk listener/ingester and invoke them from the ES helper, not the profile or `MainClass`: done; `MainClass` is thin again.
- Drop the gate, the delete/update counts and the index-OK diagnostics (`reconcileLivePoints`, `getLiveAliasDocsStats`, `assertSafeToReindex`): all removed; a single end-of-run stats line replaces them.
- Remove the one-line failure-counter method: inlined at the call sites.
- Nothing should exist solely for tests: removed the test-only `resubmitWithBackoff(..., BulkAttempt, BackoffSleep)` overload and its interfaces; the retry path is tested through `afterBulk`.
- Comments too verbose, no ADR references, no HTML: comment-to-code ratio trimmed; rationale moved to method javadoc.

Part of splitting #63 into small, independent, non-breaking increments (bugfixes first). Companion PRs: volcano icon, `--skip-tiles`, ranking signals.
