### PR TITLE
Treat natural=volcano like natural=peak in the icon classifier

### DIFF
--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -984,7 +984,10 @@ public class PlanetSearchProfile implements Profile {
       }
     }
 
-    if ("peak".equals(feature.getString("natural"))) {
+    // Treat natural=volcano like natural=peak so named summit nodes tagged as volcanoes get the
+    // peak icon instead of the icon-search default, which would otherwise drop them.
+    String natural = feature.getString("natural");
+    if ("peak".equals(natural) || "volcano".equals(natural)) {
       pointDocument.poiIconColor = "black";
       pointDocument.poiIcon = "icon-peak";
       pointDocument.poiCategory = "Natural";

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -984,8 +984,6 @@ public class PlanetSearchProfile implements Profile {
       }
     }
 
-    // Treat natural=volcano like natural=peak so named summit nodes tagged as volcanoes get the
-    // peak icon instead of the icon-search default, which would otherwise drop them.
     String natural = feature.getString("natural");
     if ("peak".equals(natural) || "volcano".equals(natural)) {
       pointDocument.poiIconColor = "black";

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -907,6 +907,13 @@ public class PlanetSearchProfile implements Profile {
           pointDocument.poiIcon = "icon-waterhole";
           pointDocument.poiCategory = "Water";
           return;
+        case "peak":
+        case "volcano":
+        case "ridge":
+          pointDocument.poiIconColor = "black";
+          pointDocument.poiIcon = "icon-peak";
+          pointDocument.poiCategory = "Natural";
+          return;
       }
     }
 
@@ -982,14 +989,6 @@ public class PlanetSearchProfile implements Profile {
           pointDocument.poiCategory = "Camping";
           return;
       }
-    }
-
-    String natural = feature.getString("natural");
-    if ("peak".equals(natural) || "volcano".equals(natural)) {
-      pointDocument.poiIconColor = "black";
-      pointDocument.poiIcon = "icon-peak";
-      pointDocument.poiCategory = "Natural";
-      return;
     }
 
     if (feature.getString("highway") != null) {


### PR DESCRIPTION
## What

Named `natural=volcano` summit nodes were falling through to the `icon-search` default and getting dropped by `processOtherSourceFeature`. Map them to `icon-peak`, the same way `natural=peak` is handled.

## New OSM tag support

This adds support for `natural=volcano`. The Site repo must be updated to surface this tag in search results.

## Notes

Covered by the existing E2E path. The icon classifier is private, so no unit-test seam was added. Non-breaking and independent.

Review note from #63: HarelM suggested volcano as a good addition similar to peak, and asked for a note that this adds new OSM tag support; both the mapping and the note are above.

Part of splitting #63 into small, independent, non-breaking increments. Companion PRs: indexer resilience, `--skip-tiles`, ranking signals.
