### PR TITLE
Add --skip-tiles to collapse tiles for a faster ES-only reindex

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Additional arguments to this wrapper besides the Planetiler's arguments:
 | `es-points-index-alias` | The alias of the index to insert points into, it will create "1" and "2" suffix for the relevant index before switching | `points` |
 | `es-bbox-index-alias` | The alias of the index to insert bounding boxes into, it will create "1" and "2" suffix for the relevant index before switching | `bbox` |
 | `external-file-path` | External geojson file path to allow adding non OSM features to the search and POIs. these features should have a specific format | "empty" |
+| `skip-tiles` | Collapse the tile pyramid to z0 so the `.pmtiles` archive is a near-instant stub, to speed up an Elasticsearch-only reindex. The search index is built identically; only the map tiles degrade, so do not use it for a build whose map tiles are consumed. | `false` |
 
 To run using docker (While having a local elasticsearch running at 9200):
 

--- a/src/main/java/il/org/osm/israelhiking/MainClass.java
+++ b/src/main/java/il/org/osm/israelhiking/MainClass.java
@@ -6,11 +6,14 @@ import com.onthegomap.planetiler.config.Arguments;
 import co.elastic.clients.elasticsearch.inference.ElserServiceSettings;
 
 import java.nio.file.Path;
+import java.util.logging.Logger;
 
 /**
  * The main entry point
  */
 public class MainClass {
+
+    private static final Logger LOGGER = Logger.getLogger(MainClass.class.getName());
 
     /** Static utility class should not be instantiated. */
     private MainClass() {
@@ -26,6 +29,17 @@ public class MainClass {
     }
 
     static void run(Arguments args) throws Exception {
+        boolean skipTiles = args.getBoolean("skip-tiles",
+                "Collapse tile output to z0 (near-instant archive) to speed up an ES-only reindex; "
+                        + "map tiles become a stub. Default false — leave off when tiles are needed.",
+                false);
+        if (skipTiles) {
+            LOGGER.warning("skip-tiles=true: collapsing tile output to z0. The ES search index is "
+                    + "built normally; the .pmtiles archive will be a stub. Do NOT use for a build "
+                    + "whose map tiles are consumed (client / production map).");
+            // Override only the zoom args (not the whole Arguments) — do not re-broaden this.
+            args = Arguments.of("maxzoom", "0", "render_maxzoom", "0").orElse(args);
+        }
         Planetiler planetiler = Planetiler.create(args);
 
         var esAddress = args.getString("es-address", "Elasticsearch address", "http://localhost:9200");


### PR DESCRIPTION
## What

Adds an opt-in `--skip-tiles` flag. When set, it overrides only `maxzoom` and `render_maxzoom` to 0, so the `.pmtiles` archive becomes a near-instant stub while the Elasticsearch search index is built identically. This speeds up reindex runs where the map tiles are not needed.

The override uses `Arguments.of("maxzoom", "0", "render_maxzoom", "0").orElse(args)`, which merges over the user's other arguments rather than replacing the whole args variable.

Default is `false`. Documented in the README. Non-breaking and independent.

## Review notes addressed (from #63)

- A previous version of this flag overrode the entire args variable, which HarelM removed. This version updates only the two zoom arguments and falls back to everything else the user passed.
- Add the flag to the README: done, in the arguments table.

Part of splitting #63 into small, independent, non-breaking increments. Companion PRs: indexer resilience, volcano icon, ranking signals.
