### PR TITLE
Add index-time ranking signals (prominence, QRank, feature_class, area, population, alt_names)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Additional arguments to this wrapper besides the Planetiler's arguments:
 | `es-points-index-alias` | The alias of the index to insert points into, it will create "1" and "2" suffix for the relevant index before switching | `points` |
 | `es-bbox-index-alias` | The alias of the index to insert bounding boxes into, it will create "1" and "2" suffix for the relevant index before switching | `bbox` |
 | `external-file-path` | External geojson file path to allow adding non OSM features to the search and POIs. these features should have a specific format | "empty" |
+| `qrank-path` | Path to a `qrank.csv.gz` file (Wikimedia pageview ranks, from https://qrank.toolforge.org) used to boost the prominence of well-known features. Leave empty to build without QRank — all QRank lookups then contribute 0. | "empty" |
 
 To run using docker (While having a local elasticsearch running at 9200):
 
@@ -37,4 +38,19 @@ You can also do the same with Docker locally:
 To serve the PMTiles run:
 
 `docker run --rm -p 7777:8080 -v $(pwd)/data/target/:/data/ --rm protomaps/go-pmtiles serve /data/ --public-url=http://localhost:7777 --cors=\*`
+
+## QRank ranking signal (optional)
+
+QRank (Wikimedia pageview ranks) boosts the prominence of well-known features so a famous peak or
+city outranks an obscure node with the same name. It is optional — without it, every QRank lookup
+contributes 0 and ranking still works.
+
+To use it, download the gzipped file and pass its path via `qrank-path`:
+
+```
+curl -L -o data/qrank.csv.gz https://qrank.toolforge.org/download/qrank.csv.gz
+java -cp "target/classes:target/dependency/*" il.org.osm.israelhiking.MainClass --qrank-path=data/qrank.csv.gz
+```
+
+The file is large (~360 MB) and loading it adds a few hundred MB of resident memory during the build.
 

--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -15,6 +15,21 @@ import co.elastic.clients.transport.rest_client.RestClientTransport;
 
 public class ElasticsearchHelper {
 
+  // Doubled-only: folding a single vav/yod would merge real homographs. "\\u" reaches ES as the literal Lucene escape.
+  static final String HEBREW_VAV = "ו";
+  static final String HEBREW_YOD = "י";
+  static final String HEBREW_DOUBLED_VAV_PATTERN = "\\u05D5\\u05D5";
+  static final String HEBREW_DOUBLED_YOD_PATTERN = "\\u05D9\\u05D9";
+
+  static String applyHebrewMatresDoubledOnly(String input) {
+    if (input == null) {
+      return null;
+    }
+    return input
+        .replaceAll("וו", HEBREW_VAV)
+        .replaceAll("יי", HEBREW_YOD);
+  }
+
   public static record ElasticRunContext(
       ElasticsearchClient esClient,
       String pointsIndexAlias,
@@ -53,25 +68,86 @@ public class ElasticsearchHelper {
                         .patternReplace(pr -> pr
                             .pattern("[\\u05B0-\\u05C7]")
                             .replacement(""))))
+                // he-scoped only, so the matres fold's blast radius stays in Hebrew.
+                .charFilter("hebrew_matres", cf -> cf
+                    .definition(d -> d
+                        .patternReplace(pr -> pr
+                            .pattern(HEBREW_DOUBLED_VAV_PATTERN)
+                            .replacement(HEBREW_VAV))))
+                .charFilter("hebrew_matres_yod", cf -> cf
+                    .definition(d -> d
+                        .patternReplace(pr -> pr
+                            .pattern(HEBREW_DOUBLED_YOD_PATTERN)
+                            .replacement(HEBREW_YOD))))
+                .filter("edge_ngram_2_15", tf -> tf
+                    .definition(d -> d
+                        .edgeNgram(en -> en.minGram(2).maxGram(15))))
                 .normalizer("universal_normalizer", n -> n
                     .custom(cn -> cn
                         .charFilter("hebrew_niqqud")
+                        .filter("asciifolding", "lowercase")))
+                .normalizer("hebrew_normalizer", n -> n
+                    .custom(cn -> cn
+                        .charFilter("hebrew_niqqud", "hebrew_matres", "hebrew_matres_yod")
                         .filter("asciifolding", "lowercase")))
                 .analyzer("universal_analyzer", an -> an
                     .custom(ca -> ca
                         .charFilter("hebrew_niqqud")
                         .tokenizer("standard")
+                        .filter("asciifolding", "lowercase")))
+                .analyzer("hebrew_analyzer", an -> an
+                    .custom(ca -> ca
+                        .charFilter("hebrew_niqqud", "hebrew_matres", "hebrew_matres_yod")
+                        .tokenizer("standard")
+                        .filter("asciifolding", "lowercase")))
+                .analyzer("prefix_index_analyzer", an -> an
+                    .custom(ca -> ca
+                        .charFilter("hebrew_niqqud")
+                        .tokenizer("standard")
+                        .filter("asciifolding", "lowercase", "edge_ngram_2_15")))
+                // No edge_ngram: the query term must not be exploded into grams.
+                .analyzer("prefix_search_analyzer", an -> an
+                    .custom(ca -> ca
+                        .charFilter("hebrew_niqqud")
+                        .tokenizer("standard")
+                        .filter("asciifolding", "lowercase")))
+                .analyzer("hebrew_prefix_index_analyzer", an -> an
+                    .custom(ca -> ca
+                        .charFilter("hebrew_niqqud", "hebrew_matres", "hebrew_matres_yod")
+                        .tokenizer("standard")
+                        .filter("asciifolding", "lowercase", "edge_ngram_2_15")))
+                .analyzer("hebrew_prefix_search_analyzer", an -> an
+                    .custom(ca -> ca
+                        .charFilter("hebrew_niqqud", "hebrew_matres", "hebrew_matres_yod")
+                        .tokenizer("standard")
                         .filter("asciifolding", "lowercase")))))
         .mappings(m -> {
           for (var lang : allLanguages) {
+            var isHebrew = "he".equals(lang);
             m.properties("name." + lang, k -> k
                 .text(p -> p
-                    .analyzer("universal_analyzer")
+                    .analyzer(isHebrew ? "hebrew_analyzer" : "universal_analyzer")
                     .fields("keyword", f -> f
                         .keyword(kw -> kw
-                            .normalizer("universal_normalizer")))));
+                            .normalizer(isHebrew ? "hebrew_normalizer" : "universal_normalizer")))
+                    .fields("prefix", f -> f
+                        .text(pt -> pt
+                            .analyzer(isHebrew ? "hebrew_prefix_index_analyzer" : "prefix_index_analyzer")
+                            .searchAnalyzer(isHebrew ? "hebrew_prefix_search_analyzer" : "prefix_search_analyzer")))));
+            m.properties("alt_names." + lang, k -> k
+                .text(p -> p
+                    .analyzer(isHebrew ? "hebrew_analyzer" : "universal_analyzer")
+                    .fields("keyword", f -> f
+                        .keyword(kw -> kw
+                            .normalizer(isHebrew ? "hebrew_normalizer" : "universal_normalizer")))));
           }
           m.properties("location", g -> g.geoPoint(p -> p));
+          // Absent => ES uses missing:1.0, so old docs keep working.
+          m.properties("poiProminence", n -> n.float_(f -> f));
+          m.properties("population", n -> n.integer(f -> f));
+          m.properties("poiFeatureClass", n -> n.keyword(f -> f));
+          m.properties("poiAreaNormalized", n -> n.float_(f -> f.index(false)));
+          m.properties("intermittent", n -> n.boolean_(f -> f.index(false)));
           return m;
         }));
 

--- a/src/main/java/il/org/osm/israelhiking/MainClass.java
+++ b/src/main/java/il/org/osm/israelhiking/MainClass.java
@@ -3,8 +3,6 @@ package il.org.osm.israelhiking;
 import com.onthegomap.planetiler.Planetiler;
 import com.onthegomap.planetiler.config.Arguments;
 
-import co.elastic.clients.elasticsearch.inference.ElserServiceSettings;
-
 import java.nio.file.Path;
 
 /**
@@ -37,9 +35,12 @@ public class MainClass {
                     "bbox");
             var supportedLanguages = args.getString("languages", "Languages to support", "en,he,ru,ar,es").split(",");
             var externalFilePath = args.getString("external-file-path", "External file path", "");
+            var qrankPath = args.getString("qrank-path",
+                    "Path to qrank.csv.gz for the prominence signal (empty to run without QRank)", "");
+            var qrankIndex = QRankIndex.load(qrankPath.isEmpty() ? null : Path.of(qrankPath));
             var context = ElasticsearchHelper.initRun(esClient, pointsIndexAlias, bboxIndexAlias,
                     supportedLanguages);
-            var profile = new PlanetSearchProfile(planetiler.config(), context);
+            var profile = new PlanetSearchProfile(planetiler.config(), context, qrankIndex);
 
             String area = args.getString("area", "geofabrik area to download", "israel-and-palestine");
             planetiler.setProfile(profile);

--- a/src/main/java/il/org/osm/israelhiking/OsmTagUtils.java
+++ b/src/main/java/il/org/osm/israelhiking/OsmTagUtils.java
@@ -1,0 +1,284 @@
+package il.org.osm.israelhiking;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+final class OsmTagUtils {
+
+  private OsmTagUtils() {
+  }
+
+  static String classifyFeatureClass(Function<String, String> tagLookup) {
+    String natural = tagLookup.apply("natural");
+    String waterway = tagLookup.apply("waterway");
+    String place = tagLookup.apply("place");
+    String historic = tagLookup.apply("historic");
+    String tourism = tagLookup.apply("tourism");
+    String leisure = tagLookup.apply("leisure");
+    String amenity = tagLookup.apply("amenity");
+    String shop = tagLookup.apply("shop");
+    String office = tagLookup.apply("office");
+    String craft = tagLookup.apply("craft");
+    String healthcare = tagLookup.apply("healthcare");
+    String manMade = tagLookup.apply("man_made");
+    String building = tagLookup.apply("building");
+
+    String fc = null;
+    if (natural != null) {
+      switch (natural) {
+        case "peak":                  fc = "peak"; break;
+        case "volcano":               fc = "peak"; break;
+        case "hill":                  fc = "hill"; break;
+        case "ridge":                 fc = "ridge"; break;
+        case "saddle": case "gap":    fc = "saddle"; break;
+        case "cliff":                 fc = "cliff"; break;
+        case "rock": case "stone":    fc = "rock"; break;
+        case "water":                 fc = "lake"; break;
+        case "spring": case "hot_spring": fc = "spring"; break;
+        case "glacier":               fc = "glacier"; break;
+        case "bay":                   fc = "bay"; break;
+        case "cape":                  fc = "cape"; break;
+        case "beach":                 fc = "beach"; break;
+        case "wood": case "forest":   fc = "forest"; break;
+        case "valley":                fc = "valley"; break;
+        case "canyon": case "gorge":  fc = "canyon"; break;
+        case "mesa": case "plateau":  fc = "plateau"; break;
+        case "arch":                  fc = "arch"; break;
+        case "cave_entrance":         fc = "cave"; break;
+        case "wetland":               fc = "wetland"; break;
+        case "arete":                 fc = "ridge"; break;
+        case "crater":                fc = "peak"; break;
+        case "mountain_range":        fc = "peak"; break;
+        default:                      fc = "natural"; break;
+      }
+      String water = tagLookup.apply("water");
+      if ("water".equals(natural) && water != null) {
+        switch (water) {
+          case "lake":      fc = "lake"; break;
+          case "reservoir": fc = "reservoir"; break;
+          case "pond":      fc = "pond"; break;
+          case "river":     fc = "river"; break;
+          case "canal":     fc = "canal"; break;
+          case "lagoon":    fc = "lagoon"; break;
+          default:          fc = "water"; break;
+        }
+      }
+    } else if (waterway != null) {
+      switch (waterway) {
+        case "waterfall":             fc = "waterfall"; break;
+        case "river":                 fc = "river"; break;
+        case "stream":                fc = "stream"; break;
+        case "canal":                 fc = "canal"; break;
+        case "rapids":                fc = "rapids"; break;
+        default:                      fc = "waterway"; break;
+      }
+    } else if (place != null) {
+      switch (place) {
+        case "city": case "town": case "village": case "hamlet":
+        case "suburb": case "neighbourhood":
+                                      fc = place; break;
+        case "island": case "islet": fc = "island"; break;
+        case "locality":             fc = "locality"; break;
+        default:                      fc = "place"; break;
+      }
+    } else if (historic != null) {
+      fc = "historic";
+    } else if (tourism != null) {
+      switch (tourism) {
+        case "viewpoint":             fc = "viewpoint"; break;
+        case "camp_site":             fc = "campsite"; break;
+        case "attraction":            fc = "attraction"; break;
+        case "hotel": case "motel": case "hostel": case "guest_house":
+        case "apartment": case "chalet": case "alpine_hut": case "wilderness_hut":
+                                      fc = "lodging"; break;
+        case "museum": case "gallery": fc = "museum"; break;
+        case "information":           fc = "tourism"; break;
+        default:                      fc = "tourism"; break;
+      }
+    } else if (leisure != null) {
+      switch (leisure) {
+        case "park": case "garden": case "nature_reserve":
+        case "playground": case "dog_park": case "common":
+                                      fc = "park"; break;
+        case "sports_centre": case "stadium": case "pitch": case "track":
+        case "fitness_centre": case "swimming_pool": case "golf_course":
+        case "ice_rink": case "horse_riding":
+                                      fc = "sports"; break;
+        default:                      fc = "leisure"; break;
+      }
+    } else if (amenity != null) {
+      switch (amenity) {
+        case "restaurant": case "cafe": case "fast_food": case "bar":
+        case "pub": case "food_court": case "biergarten": case "ice_cream":
+                                      fc = "food"; break;
+        case "place_of_worship": case "monastery":
+                                      fc = "religious"; break;
+        case "school": case "university": case "college": case "kindergarten":
+        case "library":
+                                      fc = "education"; break;
+        case "hospital": case "clinic": case "pharmacy": case "doctors":
+        case "dentist": case "veterinary":
+                                      fc = "medical"; break;
+        case "townhall": case "courthouse": case "police": case "fire_station":
+        case "post_office": case "embassy": case "prison":
+                                      fc = "government"; break;
+        case "fuel": case "charging_station":
+                                      fc = "fuel"; break;
+        case "parking": case "parking_space": case "bicycle_parking":
+        case "motorcycle_parking": case "taxi":
+                                      fc = "parking"; break;
+        case "bus_station": case "ferry_terminal":
+                                      fc = "transit"; break;
+        case "theatre": case "cinema": case "arts_centre":
+                                      fc = "museum"; break;
+        default:                      fc = "amenity"; break;
+      }
+    } else if (shop != null) {
+      fc = "shop";
+    } else if (office != null) {
+      fc = "office";
+    } else if (craft != null) {
+      fc = "office";
+    } else if (healthcare != null) {
+      fc = "medical";
+    } else if (manMade != null) {
+      switch (manMade) {
+        case "tower": case "lighthouse": case "bridge": case "obelisk":
+        case "water_tower": case "windmill": case "watermill": case "pier":
+                                      fc = "structure"; break;
+        default:                      fc = "man_made"; break;
+      }
+    } else if (building != null && !"no".equals(building) && !"none".equals(building)
+               && !"No".equals(building)) {
+      switch (building) {
+        case "church": case "chapel": case "cathedral": case "mosque":
+        case "synagogue": case "temple": case "shrine":
+                                      fc = "religious"; break;
+        case "hotel":                 fc = "lodging"; break;
+        case "hospital":              fc = "medical"; break;
+        case "school": case "university": case "college":
+                                      fc = "education"; break;
+        case "train_station":         fc = "transit"; break;
+        default:                      fc = "building"; break;
+      }
+    }
+    return fc;
+  }
+
+  private static final String[] ALT_NAME_TAG_BASES = {
+      "alt_name", "official_name", "short_name", "loc_name", "int_name"
+  };
+
+  /** old_name is deliberately excluded — a stale former name can overtake the real one. */
+  static Map<String, List<String>> buildAltNames(String[] supportedLanguages,
+      Function<String, String> tagLookup) {
+    Map<String, List<String>> altNames = null;
+    for (String language : supportedLanguages) {
+      var suffixedTags = Arrays.stream(ALT_NAME_TAG_BASES)
+          .map(base -> base + ":" + language)
+          .toArray(String[]::new);
+      var collected = collectVariants(tagLookup, suffixedTags);
+      if (collected != null) {
+        if (altNames == null) {
+          altNames = new HashMap<String, List<String>>();
+        }
+        altNames.put(language, collected);
+      }
+    }
+    var collectedDefault = collectVariants(tagLookup, ALT_NAME_TAG_BASES);
+    if (collectedDefault != null) {
+      if (altNames == null) {
+        altNames = new HashMap<String, List<String>>();
+      }
+      altNames.put("default", collectedDefault);
+    }
+    return altNames;
+  }
+
+  private static List<String> collectVariants(Function<String, String> tagLookup, String[] tags) {
+    var variants = new LinkedHashSet<String>();
+    for (String tag : tags) {
+      var raw = tagLookup.apply(tag);
+      if (raw == null || raw.isEmpty()) {
+        continue;
+      }
+      for (String part : raw.split(";")) {
+        var trimmed = part.trim();
+        if (!trimmed.isEmpty()) {
+          variants.add(trimmed);
+        }
+      }
+    }
+    return variants.isEmpty() ? null : new ArrayList<>(variants);
+  }
+
+  // Lowercase 'm' excluded: it's metres, so "1500m" parses to 1500, not mega.
+  private static final String GLUED_MAGNITUDE_SUFFIXES = "kKMB";
+  private static final double[] GLUED_MAGNITUDE_VALUES = { 1e3, 1e3, 1e6, 1e9 };
+
+  static double parseFirstNumber(String raw) {
+    if (raw == null) {
+      return Double.NaN;
+    }
+    StringBuilder sb = new StringBuilder();
+    boolean seenDigit = false;
+    boolean seenDot = false;
+    boolean seenSign = false;
+    boolean lastWasNumeric = false;
+    double multiplier = 1.0;
+    for (int i = 0; i < raw.length(); i++) {
+      char c = raw.charAt(i);
+      if (c >= '0' && c <= '9') {
+        sb.append(c);
+        seenDigit = true;
+        lastWasNumeric = true;
+      } else if (c == '-' && !seenDigit && !seenSign) {
+        sb.append(c);
+        seenSign = true;
+      } else if (c == '.' && seenDigit && !seenDot) {
+        sb.append(c);
+        seenDot = true;
+        lastWasNumeric = true;
+      } else if ((c == ',' || c == ' ' || c == '\'') && seenDigit) {
+        lastWasNumeric = false;
+      } else if (seenDigit) {
+        int magIdx = lastWasNumeric ? GLUED_MAGNITUDE_SUFFIXES.indexOf(c) : -1;
+        if (magIdx >= 0) {
+          multiplier = GLUED_MAGNITUDE_VALUES[magIdx];
+        }
+        break;
+      }
+    }
+    if (!seenDigit) {
+      return Double.NaN;
+    }
+    try {
+      return Double.parseDouble(sb.toString()) * multiplier;
+    } catch (NumberFormatException e) {
+      return Double.NaN;
+    }
+  }
+
+  /** isFinite rejects a +Infinity overflow that would otherwise pin to MAX_VALUE; null lets ES use missing:1.0. */
+  static Integer computePopulation(String place, String populationTag) {
+    if (place == null) {
+      return null;
+    }
+    double parsed = parseFirstNumber(populationTag);
+    if (Double.isFinite(parsed) && parsed >= 1) {
+      return (int) Math.min(parsed, Integer.MAX_VALUE);
+    }
+    switch (place) {
+      case "city":    return 1_000_000;
+      case "town":    return 50_000;
+      case "village": return 2_000;
+      case "hamlet":  return 200;
+      default:        return null;
+    }
+  }
+}

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.math.NumberUtils;
@@ -30,8 +31,11 @@ import com.onthegomap.planetiler.reader.osm.OsmRelationInfo;
 import il.org.osm.israelhiking.ElasticsearchHelper.ElasticRunContext;
 
 public class PlanetSearchProfile implements Profile {
+  private static final Logger LOGGER = Logger.getLogger(PlanetSearchProfile.class.getName());
+
   private PlanetilerConfig config;
   private ElasticRunContext context;
+  private final QRankIndex qrankIndex;
 
   public static final String POINTS_LAYER_NAME = "global_points";
 
@@ -39,9 +43,10 @@ public class PlanetSearchProfile implements Profile {
   private static final Map<String, MinWayIdFinder> NamedHighways = new ConcurrentHashMap<>();
   private static final Map<String, MinWayIdFinder> Waterways = new ConcurrentHashMap<>();
 
-  public PlanetSearchProfile(PlanetilerConfig config, ElasticRunContext context) {
+  public PlanetSearchProfile(PlanetilerConfig config, ElasticRunContext context, QRankIndex qrankIndex) {
     this.config = config;
     this.context = context;
+    this.qrankIndex = qrankIndex;
   }
 
   /*
@@ -95,6 +100,57 @@ public class PlanetSearchProfile implements Profile {
     pointDocument.image = feature.getString("image");
     pointDocument.wikimedia_commons = feature.getString("wikimedia_commons");
     pointDocument.website = feature.getString("website");
+    pointDocument.poiFeatureClass = OsmTagUtils.classifyFeatureClass(feature::getString);
+    pointDocument.alt_names = OsmTagUtils.buildAltNames(this.context.supportedLanguages(), feature::getString);
+    pointDocument.population = OsmTagUtils.computePopulation(
+        feature.getString("place"), feature.getString("population"));
+    setEnrichmentSignals(pointDocument, feature);
+    // Must run after wikidata/image/website are set above.
+    setProminence(pointDocument, feature);
+  }
+
+  private void setEnrichmentSignals(PointDocument pointDocument, WithTags feature) {
+    if (feature instanceof SourceFeature sf && sf.canBePolygon()) {
+      try {
+        pointDocument.poiAreaNormalized = normalizeArea(sf.areaMeters());
+      } catch (Exception e) {
+        // Unbuildable polygons are common here; never fail the build over one.
+        LOGGER.fine(() -> "poiAreaNormalized skipped for " + sourceFeatureToDocumentId(sf)
+            + " (" + e.getClass().getSimpleName() + ": " + e.getMessage() + ")");
+      }
+    }
+    if (feature.hasTag("intermittent", "yes")) {
+      pointDocument.intermittent = Boolean.TRUE;
+    }
+  }
+
+  static float normalizeArea(double areaM) {
+    if (Double.isNaN(areaM) || areaM <= 0) {
+      return 0f;
+    }
+    double norm = Math.log1p(areaM) / Math.log1p(1e11);
+    return (float) Math.max(0.0, Math.min(1.0, norm));
+  }
+
+  private void setProminence(PointDocument pointDocument, WithTags feature) {
+    long qrankRaw = qrankIndex.getByWikidata(pointDocument.wikidata);
+    double ele = OsmTagUtils.parseFirstNumber(feature.getString("ele"));
+    boolean hasImage = pointDocument.image != null || pointDocument.wikimedia_commons != null;
+    boolean hasWebsite = pointDocument.website != null;
+    boolean hasWikidata = pointDocument.wikidata != null;
+
+    pointDocument.poiProminence = ProminenceCalculator.compute(
+        pointDocument.poiFeatureClass, ele, hasImage, hasWebsite, hasWikidata, qrankRaw);
+  }
+
+  static float flooredProminence(Float prominence) {
+    return prominence == null ? (float) ProminenceCalculator.FLOOR : prominence;
+  }
+
+  static boolean isPlainTrailIcon(String poiIcon) {
+    return "icon-hike".equals(poiIcon)
+        || "icon-bike".equals(poiIcon)
+        || "icon-four-by-four".equals(poiIcon);
   }
 
   private void setDifficulty(PointDocument pointDocument, WithTags feature) {
@@ -496,9 +552,7 @@ public class PlanetSearchProfile implements Profile {
         pointDocument.location = new double[] { lngLatPoint.getX(), lngLatPoint.getY() };
         insertPointToElasticsearch(pointDocument, "OSM_way_" + mergedFeature.minId);
 
-        if (pointDocument.poiIcon == "icon-hike" ||
-            pointDocument.poiIcon == "icon-bike" ||
-            pointDocument.poiIcon == "icon-four-by-four") {
+        if (isPlainTrailIcon(pointDocument.poiIcon)) {
           continue;
         }
         // This is a highway with a name, but it's not just a highway as it has a
@@ -605,19 +659,7 @@ public class PlanetSearchProfile implements Profile {
       pointDocument.poiIcon = "icon-wikipedia-w";
       pointDocument.poiCategory = "Wikipedia";
     }
-    for (String language : this.context.supportedLanguages()) {
-      CoalesceIntoMap(pointDocument.name, language, feature.getString("name:" + language));
-      CoalesceIntoMap(pointDocument.description, language, feature.getString("description:" + language));
-    }
-    if (feature.hasTag("name")) {
-      CoalesceIntoMap(pointDocument.name, "default", feature.getString("name"));
-    }
-    if (feature.hasTag("description")) {
-      CoalesceIntoMap(pointDocument.description, "default", feature.getString("description"));
-    }
-    pointDocument.wikidata = feature.getString("wikidata");
-    pointDocument.image = feature.getString("image");
-    pointDocument.wikimedia_commons = feature.getString("wikimedia_commons");
+    convertTagsToDocument(pointDocument, feature);
     pointDocument.poiSource = "OSM";
     var docId = sourceFeatureToDocumentId(feature);
     var point = feature.canBePolygon() ? (Point) feature.centroidIfConvex()
@@ -628,6 +670,7 @@ public class PlanetSearchProfile implements Profile {
   }
 
   private void insertPointToElasticsearch(PointDocument pointDocument, String docId) {
+    pointDocument.poiProminence = flooredProminence(pointDocument.poiProminence);
     try {
       this.context.esClient().index(i -> i
           .index(this.context.pointsIndexTarget())

--- a/src/main/java/il/org/osm/israelhiking/PointDocument.java
+++ b/src/main/java/il/org/osm/israelhiking/PointDocument.java
@@ -1,10 +1,15 @@
 package il.org.osm.israelhiking;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 class PointDocument {
   public Map<String, String> name = new HashMap<String, String>();
+  public Map<String, List<String>> alt_names;
   public Map<String, String> description = new HashMap<String, String>();
   public String wikidata;
   public String image;
@@ -14,8 +19,14 @@ class PointDocument {
   public String poiIconColor;
   public String poiSource;
   public String poiDifficulty;
-  /** Length is in meters */
   public double poiLength = 0;
   public String website;
   public double[] location;
+
+  // null => omitted (NON_NULL) so ES uses missing:1.0 and old docs keep working.
+  public Float poiProminence;
+  public Float poiAreaNormalized;
+  public Boolean intermittent;
+  public Integer population;
+  public String poiFeatureClass;
 }

--- a/src/main/java/il/org/osm/israelhiking/ProminenceCalculator.java
+++ b/src/main/java/il/org/osm/israelhiking/ProminenceCalculator.java
@@ -1,0 +1,52 @@
+package il.org.osm.israelhiking;
+
+final class ProminenceCalculator {
+
+  static final double QRANK_REF = 3_000_000.0;
+  static final double MAX_ELE_M = 8849.0;
+  /** Never zero, so the query-time multiply can't annihilate a hit. */
+  static final double FLOOR = 0.05;
+
+  private ProminenceCalculator() {}
+
+  static float compute(String featureClass, double ele, boolean hasImage, boolean hasWebsite,
+      boolean hasWikidata, long qrankRaw) {
+
+    double eleNorm = Double.isNaN(ele) ? 0.0 : clamp01(Math.log1p(Math.max(0, ele)) / Math.log1p(MAX_ELE_M));
+    double base = basePrior(featureClass, eleNorm);
+    double qnorm = (qrankRaw <= 1) ? 0.0 : clamp01(Math.log(qrankRaw) / Math.log(QRANK_REF));
+    double meta = clamp01(0.40 * (hasImage ? 1 : 0) + 0.35 * (hasWebsite ? 1 : 0) + 0.25 * (hasWikidata ? 1 : 0));
+
+    return (float) clamp01(FLOOR + 0.45 * base + 0.40 * qnorm + 0.10 * meta);
+  }
+
+  private static double basePrior(String featureClass, double eleNorm) {
+    if (featureClass == null) {
+      return 0.25;
+    }
+    switch (featureClass) {
+      case "peak":            return 0.30 + 0.55 * eleNorm;
+      case "city":            return 1.00;
+      case "town":            return 0.80;
+      case "village":         return 0.55;
+      case "hamlet":          return 0.35;
+      case "suburb": case "neighbourhood": case "island": case "locality": case "place":
+                              return 0.45;
+      case "park":            return 0.80;
+      case "viewpoint": case "attraction": case "lodging":
+                              return 0.55;
+      case "historic":        return 0.55;
+      case "spring": case "cave":
+      case "river": case "stream": case "canal": case "waterfall": case "rapids": case "waterway":
+                              return 0.30;
+      default:                return 0.25;
+    }
+  }
+
+  static double clamp01(double v) {
+    if (Double.isNaN(v)) return 0; // Math.min/max pass NaN through; keep it out of the ES score
+    if (v < 0) return 0;
+    if (v > 1) return 1;
+    return v;
+  }
+}

--- a/src/main/java/il/org/osm/israelhiking/QRankIndex.java
+++ b/src/main/java/il/org/osm/israelhiking/QRankIndex.java
@@ -1,0 +1,94 @@
+package il.org.osm.israelhiking;
+
+import com.carrotsearch.hppc.LongIntHashMap;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.logging.Logger;
+import java.util.zip.GZIPInputStream;
+
+/** QRank by Wikidata Q-id, from qrank.csv.gz (https://qrank.toolforge.org, CC0). */
+class QRankIndex {
+  private static final Logger LOGGER = Logger.getLogger(QRankIndex.class.getName());
+
+  private final LongIntHashMap qrankByQid;
+
+  private QRankIndex(LongIntHashMap qrankByQid) {
+    this.qrankByQid = qrankByQid;
+  }
+
+  static QRankIndex empty() {
+    return new QRankIndex(new LongIntHashMap(0));
+  }
+
+  static QRankIndex load(Path csvGz) {
+    if (csvGz == null || !Files.isRegularFile(csvGz)) {
+      LOGGER.info("QRankIndex: no QRank file provided — running with an empty index (lookups return 0)");
+      return empty();
+    }
+    long startMs = System.currentTimeMillis();
+    LongIntHashMap map = new LongIntHashMap(32_000_000);
+    long rows = 0;
+    boolean partial = false;
+    try (InputStream fis = Files.newInputStream(csvGz);
+        GZIPInputStream gz = new GZIPInputStream(fis, 1 << 16);
+        BufferedReader br = new BufferedReader(new InputStreamReader(gz, StandardCharsets.UTF_8), 1 << 20)) {
+      String line = br.readLine();
+      if (line != null && (line.length() < 2 || line.charAt(0) != 'Q')) {
+        line = br.readLine();
+      }
+      for (; line != null; line = br.readLine()) {
+        String[] cols = line.split(",", 2);
+        if (cols.length != 2 || cols[0].length() < 2 || cols[0].charAt(0) != 'Q') {
+          continue;
+        }
+        try {
+          map.put(Long.parseLong(cols[0].substring(1)), Integer.parseInt(cols[1].trim()));
+          rows++;
+        } catch (NumberFormatException ignored) {
+        }
+      }
+    } catch (Exception e) {
+      partial = true;
+      LOGGER.severe("QRankIndex: PARTIAL load of " + csvGz + " (" + e.getClass().getSimpleName()
+          + ": " + e.getMessage() + ") — only " + rows
+          + " rows loaded before failure; ranking will be skewed. Re-download the file.");
+    }
+    long heapMb = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / (1024 * 1024);
+    if (!partial) {
+      LOGGER.info("QRankIndex: loaded " + rows + " rows from " + csvGz
+          + " in " + (System.currentTimeMillis() - startMs) + "ms (heap used ~" + heapMb + " MB)");
+    }
+    return new QRankIndex(map);
+  }
+
+  long getByWikidata(String wikidata) {
+    if (wikidata == null) {
+      return 0;
+    }
+    return Arrays.stream(wikidata.split(";"))
+        .mapToLong(part -> qrankFor(part.trim()))
+        .max()
+        .orElse(0);
+  }
+
+  private long qrankFor(String token) {
+    if (token.length() < 2 || (token.charAt(0) != 'Q' && token.charAt(0) != 'q')) {
+      return 0;
+    }
+    try {
+      return qrankByQid.getOrDefault(Long.parseLong(token.substring(1)), 0);
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  int size() {
+    return qrankByQid.size();
+  }
+}

--- a/src/test/java/il/org/osm/israelhiking/AddAltNamesTest.java
+++ b/src/test/java/il/org/osm/israelhiking/AddAltNamesTest.java
@@ -1,0 +1,132 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for alt_name indexing — the pure buildAltNames helper that addAltNames delegates to
+ * (extracted so the ;-split / trim / de-dup / old_name-exclusion logic is testable without a
+ * WithTags or a real BulkIngester).
+ *
+ * The most likely correctness bug is the multi-value ; split: CoalesceIntoMap keeps only the first
+ * value and never splits, so the new code had to add splitting. These tests pin that, plus the
+ * explicit old_name exclusion.
+ */
+@Tag("unit")
+public class AddAltNamesTest {
+
+    private static final String[] LANGS = { "en", "he", "ru", "ar", "es" };
+
+    /** Build a tag-lookup function from a literal map (null for absent keys). */
+    private static Function<String, String> tags(Map<String, String> m) {
+        return m::get;
+    }
+
+    @Test
+    public void splitsSemicolonSeparatedMultiValues() {
+        // The single most likely bug: alt_name=A;B;C must become three searchable variants, not one.
+        var altNames = OsmTagUtils.buildAltNames(LANGS,
+                tags(Map.of("alt_name", "Foo;Bar;Baz")));
+        assertEquals(List.of("Foo", "Bar", "Baz"), altNames.get("default"),
+                "alt_name must be split on ';' and all variants kept");
+    }
+
+    @Test
+    public void trimsWhitespaceAndDropsEmptyParts() {
+        var altNames = OsmTagUtils.buildAltNames(LANGS,
+                tags(Map.of("alt_name", " Foo ;; Bar ;  ")));
+        assertEquals(List.of("Foo", "Bar"), altNames.get("default"),
+                "parts must be trimmed and empty parts dropped");
+    }
+
+    @Test
+    public void deDuplicatesWhileKeepingOrder() {
+        var map = new HashMap<String, String>();
+        map.put("alt_name", "Foo;Bar");
+        map.put("official_name", "Bar;Qux"); // Bar repeats across tags
+        var altNames = OsmTagUtils.buildAltNames(LANGS, tags(map));
+        assertEquals(List.of("Foo", "Bar", "Qux"), altNames.get("default"),
+                "duplicate variants across tags must be collapsed, insertion order preserved");
+    }
+
+    @Test
+    public void excludesOldName() {
+        // old_name is deliberately NOT a source tag — a stale former name must never be searchable.
+        var altNames = OsmTagUtils.buildAltNames(LANGS,
+                tags(Map.of("old_name", "Former Name")));
+        assertNull(altNames, "old_name must be excluded entirely (no alt_names produced)");
+    }
+
+    @Test
+    public void includesOfficialShortLocAndIntName() {
+        var map = new HashMap<String, String>();
+        map.put("official_name", "Official");
+        map.put("short_name", "Sh");
+        map.put("loc_name", "Local");
+        map.put("int_name", "International");
+        var altNames = OsmTagUtils.buildAltNames(LANGS, tags(map));
+        var def = altNames.get("default");
+        assertTrue(def.contains("Official"), "official_name must be indexed");
+        assertTrue(def.contains("Sh"), "short_name must be indexed");
+        assertTrue(def.contains("Local"), "loc_name must be indexed");
+        assertTrue(def.contains("International"), "int_name must be indexed");
+    }
+
+    @Test
+    public void languageSuffixedTagsGoUnderTheirLanguageKey() {
+        var map = new HashMap<String, String>();
+        map.put("alt_name:he", "המיסדים;יונתן");
+        map.put("alt_name:en", "IBT");
+        var altNames = OsmTagUtils.buildAltNames(LANGS, tags(map));
+        assertEquals(List.of("המיסדים", "יונתן"), altNames.get("he"), "alt_name:he must key under 'he', split");
+        assertEquals(List.of("IBT"), altNames.get("en"), "alt_name:en must key under 'en'");
+        assertFalse(altNames.containsKey("default"), "no bare alt_name => no 'default' key");
+    }
+
+    @Test
+    public void theIbtCase_altNameEnIbtIsSearchable() {
+        // From the live OSM relation/19598237 (the client's IBT example): alt_name:en = IBT.
+        var altNames = OsmTagUtils.buildAltNames(LANGS,
+                tags(Map.of("alt_name:en", "IBT")));
+        assertEquals(List.of("IBT"), altNames.get("en"));
+    }
+
+    @Test
+    public void languageAndDefaultTagsCoexist() {
+        // A language-suffixed tag populates the map first (altNames already non-null), then a bare
+        // default tag is added under "default" — exercising the non-null branch of the default merge.
+        var map = new HashMap<String, String>();
+        map.put("alt_name:he", "המיסדים");
+        map.put("alt_name", "Founders");
+        var altNames = OsmTagUtils.buildAltNames(LANGS, tags(map));
+        assertEquals(List.of("המיסדים"), altNames.get("he"));
+        assertEquals(List.of("Founders"), altNames.get("default"),
+                "the bare alt_name must still be added under 'default' alongside the language key");
+    }
+
+    @Test
+    public void emptyTagValueIsIgnored() {
+        // An empty-string tag value (present but blank) yields no variants — distinct from an absent
+        // (null) tag. Pins the raw.isEmpty() guard in collectVariants.
+        var altNames = OsmTagUtils.buildAltNames(LANGS, tags(Map.of("alt_name", "")));
+        assertNull(altNames, "an empty alt_name value must produce no alt_names");
+    }
+
+    @Test
+    public void noVariantTagsYieldsNull() {
+        // So addAltNames leaves alt_names null and @JsonInclude(NON_NULL) omits it from _source.
+        var altNames = OsmTagUtils.buildAltNames(LANGS,
+                tags(Map.of("name", "Just A Name", "old_name", "stale")));
+        assertNull(altNames, "a feature with no variant tags must produce no alt_names");
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/ComputePopulationTest.java
+++ b/src/test/java/il/org/osm/israelhiking/ComputePopulationTest.java
@@ -1,0 +1,114 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for OsmTagUtils.computePopulation (the place/admin population signal). Pins the two
+ * hardening fixes:
+ *   - a garbage population tag that overflows to +Infinity must NOT clamp to Integer.MAX_VALUE
+ *     (isFinite guard), and must fall through to the settlement ladder;
+ *   - a non-settlement place value must return null (no fabricated fallback), so ES uses missing:1.0.
+ */
+@Tag("unit")
+public class ComputePopulationTest {
+
+  // --- POIs (no place tag) -------------------------------------------------
+
+  @Test
+  public void nullPlaceYieldsNull() {
+    assertNull(OsmTagUtils.computePopulation(null, "12345"));
+    assertNull(OsmTagUtils.computePopulation(null, null));
+  }
+
+  // --- real population tag wins, clamped ------------------------------------
+
+  @Test
+  public void finitePositiveTagWins() {
+    assertEquals(12_345, OsmTagUtils.computePopulation("city", "12345"));
+    // free-text forms parseFirstNumber handles
+    assertEquals(1_500_000, OsmTagUtils.computePopulation("city", "1.5M"));
+    assertEquals(50_000, OsmTagUtils.computePopulation("village", "50k"));
+  }
+
+  @Test
+  public void tagOverridesLadder() {
+    // an explicit value beats the village ladder default (2_000)
+    assertEquals(9_001, OsmTagUtils.computePopulation("village", "9001"));
+  }
+
+  @Test
+  public void hugeButFiniteRealValueClampsToMaxInt() {
+    // 3e9 is finite and > Integer.MAX_VALUE -> clamp, NOT overflow to a garbage/negative int
+    assertEquals(Integer.MAX_VALUE, OsmTagUtils.computePopulation("city", "3000000000"));
+    assertEquals(Integer.MAX_VALUE, OsmTagUtils.computePopulation("city", "3B"));
+  }
+
+  // --- fix #3: +Infinity garbage tag must fall through to the ladder --------
+
+  @Test
+  public void infinityGarbageTagFallsThroughToLadder() {
+    // a several-hundred-digit run parses to +Infinity; isFinite rejects it, so a town gets the
+    // ladder value (50_000), NOT Integer.MAX_VALUE.
+    String huge = "9".repeat(400);
+    assertEquals(50_000, OsmTagUtils.computePopulation("town", huge));
+  }
+
+  @Test
+  public void infinityGarbageTagOnNonSettlementYieldsNull() {
+    String huge = "9".repeat(400);
+    assertNull(OsmTagUtils.computePopulation("island", huge));
+  }
+
+  // --- settlement ladder fallback (missing/invalid tag) ---------------------
+
+  @Test
+  public void ladderFallbackWhenTagMissing() {
+    assertEquals(1_000_000, OsmTagUtils.computePopulation("city", null));
+    assertEquals(50_000, OsmTagUtils.computePopulation("town", null));
+    assertEquals(2_000, OsmTagUtils.computePopulation("village", null));
+    assertEquals(200, OsmTagUtils.computePopulation("hamlet", null));
+  }
+
+  @Test
+  public void ladderFallbackWhenTagNonNumeric() {
+    assertEquals(2_000, OsmTagUtils.computePopulation("village", "yes"));
+    assertEquals(200, OsmTagUtils.computePopulation("hamlet", "unknown"));
+  }
+
+  @Test
+  public void zeroAndNegativeTagFallThroughToLadder() {
+    assertEquals(2_000, OsmTagUtils.computePopulation("village", "0"));
+    assertEquals(2_000, OsmTagUtils.computePopulation("village", "-5"));
+  }
+
+  @Test
+  public void subOneTagFallsThroughToLadder() {
+    assertEquals(1_000_000, OsmTagUtils.computePopulation("city", "0.4"));
+    assertEquals(2_000, OsmTagUtils.computePopulation("village", "0.9"));
+    assertNull(OsmTagUtils.computePopulation("locality", "0.4"));
+    assertEquals(1, OsmTagUtils.computePopulation("village", "1"));
+  }
+
+  // --- fix #4: non-settlement place values yield null (no fabricated 20) -----
+
+  @Test
+  public void nonSettlementPlaceYieldsNull() {
+    assertNull(OsmTagUtils.computePopulation("island", null));
+    assertNull(OsmTagUtils.computePopulation("islet", null));
+    assertNull(OsmTagUtils.computePopulation("locality", null));
+    assertNull(OsmTagUtils.computePopulation("suburb", null));
+    assertNull(OsmTagUtils.computePopulation("neighbourhood", null));
+    assertNull(OsmTagUtils.computePopulation("sea", null));
+    assertNull(OsmTagUtils.computePopulation("ocean", null));
+  }
+
+  @Test
+  public void nonSettlementPlaceWithRealTagStillUsesTag() {
+    // a locality that does carry a real population still gets it (the tag branch precedes the ladder)
+    assertEquals(1_500, OsmTagUtils.computePopulation("locality", "1500"));
+  }
+}

--- a/src/test/java/il/org/osm/israelhiking/HebrewMatresRuleTest.java
+++ b/src/test/java/il/org/osm/israelhiking/HebrewMatresRuleTest.java
@@ -1,0 +1,75 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the Hebrew matres-lectionis DOUBLED-ONLY rule that the he-scoped char_filters
+ * (hebrew_matres / hebrew_matres_yod) apply. We exercise the pure reference implementation
+ * ElasticsearchHelper.applyHebrewMatresDoubledOnly (same rule the index char_filters encode) so the
+ * doubled-vs-single behaviour is pinned without a live cluster.
+ *
+ * Scope: doubled-only is the safe, ~zero-homograph-break rule. It does NOT fix the client's
+ * אופניים/אפניים case — that needs the deferred single-interior-vav rule, which breaks ~7 real
+ * homographs (אור/אר, דוד/דד, ...) and is parked for client sign-off. These tests assert exactly
+ * that boundary.
+ */
+@Tag("unit")
+public class HebrewMatresRuleTest {
+
+    @Test
+    public void collapsesDoubledVav() {
+        // וו -> ו  (the matres-doubled-vav case the rule is FOR)
+        assertEquals("דויד", ElasticsearchHelper.applyHebrewMatresDoubledOnly("דוויד"),
+                "a doubled vav (וו) must collapse to a single vav (ו)");
+    }
+
+    @Test
+    public void collapsesDoubledYod() {
+        // יי -> י
+        assertEquals("בילי", ElasticsearchHelper.applyHebrewMatresDoubledOnly("ביילי"),
+                "a doubled yod (יי) must collapse to a single yod (י)");
+    }
+
+    @Test
+    public void collapsesDoubledAtWordStart() {
+        assertEquals("ויקי", ElasticsearchHelper.applyHebrewMatresDoubledOnly("וויקי"),
+                "doubled vav at the start must also collapse");
+    }
+
+    @Test
+    public void leavesSingleVavUntouched() {
+        // The deliberately-conservative part: a SINGLE interior vav must NOT be dropped.
+        assertEquals("אור", ElasticsearchHelper.applyHebrewMatresDoubledOnly("אור"),
+                "a single vav must be left intact (homograph-safety: אור must NOT become אר)");
+    }
+
+    @Test
+    public void leavesSingleYodUntouched() {
+        assertEquals("עיר", ElasticsearchHelper.applyHebrewMatresDoubledOnly("עיר"),
+                "a single yod must be left intact (עיר must NOT become ער)");
+    }
+
+    @Test
+    public void doesNotFixTheClientDefectiveSpelling() {
+        // Honest boundary: the client's defective spelling אפניים differs
+        // from the full אופניים by a MISSING interior vav — NOT a doubled letter. The doubled-only
+        // rule does collapse the doubled YOD that both forms share (אופניים->אופנים, אפניים->אפנים),
+        // but it leaves the vav difference intact, so the two forms STILL do not collide. Fixing
+        // HV01/HV02 needs the deferred single-interior-vav rule (which breaks ~7 homographs).
+        var full = "אופניים";     // full spelling (has the vav)
+        var defective = "אפניים"; // client's defective spelling (no vav)
+        var foldedFull = ElasticsearchHelper.applyHebrewMatresDoubledOnly(full);
+        var foldedDefective = ElasticsearchHelper.applyHebrewMatresDoubledOnly(defective);
+        org.junit.jupiter.api.Assertions.assertNotEquals(foldedFull, foldedDefective,
+                "doubled-only does NOT make full and defective spellings collide (HV01/HV02 unfixed) "
+                        + "— the missing-vav gap survives; only the deferred interior-vav rule closes it");
+    }
+
+    @Test
+    public void nullIsNull() {
+        assertEquals(null, ElasticsearchHelper.applyHebrewMatresDoubledOnly(null));
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/InsertProminenceFloorTest.java
+++ b/src/test/java/il/org/osm/israelhiking/InsertProminenceFloorTest.java
@@ -1,0 +1,78 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Modifier;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the INSERT-path prominence safety floor.
+ *
+ * This is distinct from ProminenceCalculatorTest.prominenceIsNeverZero, which guards the CALCULATOR
+ * floor. Some emit paths (ski-lift ways, relation-completion) never run convertTagsToDocument, so
+ * pointDocument.prominence arrives null at insertPointToElasticsearch. The insert-path floor must
+ * turn that null into (float) ProminenceCalculator.FLOOR (0.05) so it can't serialize as null —
+ * which, given @JsonInclude(NON_NULL), would be omitted from _source, making field_value_factor
+ * fall back to missing:1.0 and the doc unfairly outrank a real, scored feature (prominence below 1).
+ *
+ * The floored logic was extracted to the package-private static flooredProminence(Float) so it can
+ * be unit-tested without touching the private insertPointToElasticsearch / its real BulkIngester. No
+ * mock is needed: the helper is pure.
+ */
+@Tag("unit")
+public class InsertProminenceFloorTest {
+
+    @Test
+    public void nullProminenceIsFlooredToFloor() {
+        float result = PlanetSearchProfile.flooredProminence(null);
+        assertEquals((float) ProminenceCalculator.FLOOR, result, 1e-9f,
+                "a null prominence must be floored to ProminenceCalculator.FLOOR (0.05)");
+        assertEquals(0.05f, result, 1e-9f, "FLOOR is the documented 0.05 safety floor");
+    }
+
+    @Test
+    public void flooredProminenceIsNeverNull() {
+        // The whole point of the net: the result is a primitive float, never null, so the field
+        // can't be omitted from _source under @JsonInclude(NON_NULL).
+        Float result = PlanetSearchProfile.flooredProminence(null);
+        assertNotNull(result, "floored prominence must never be null");
+        assertFalse(Float.isNaN(result), "floored prominence must never be NaN");
+    }
+
+    @Test
+    public void existingProminenceIsLeftUnchanged() {
+        // The floor must NOT overwrite a real, computed value (it only fills the null gap).
+        assertEquals(0.73f, PlanetSearchProfile.flooredProminence(0.73f), 1e-9f,
+                "a real prominence must pass through unchanged");
+    }
+
+    @Test
+    public void lowButNonNullProminenceIsLeftUnchanged() {
+        // Even a value below the floor is a *real* computed value (ProminenceCalculator already
+        // clamps to >= FLOOR); the insert-path net only fills nulls, it does not re-floor.
+        assertEquals(0.01f, PlanetSearchProfile.flooredProminence(0.01f), 1e-9f,
+                "the insert net only fills nulls; it must not re-floor an existing value");
+    }
+
+    /**
+     * Build-time placement invariant. These ranking-floor computations live in the Java indexer
+     * (vendor/planet-search) and are exercised at index/emit time — NOT at C# query time. Asserting
+     * the symbols exist here (package-private static on PlanetSearchProfile, alongside
+     * ProminenceCalculator.FLOOR) pins that the guarded logic is in the indexer module, reinforcing
+     * "never compute ranking signals at query time."
+     */
+    @Test
+    public void floorLogicLivesInTheIndexerAtBuildTime() throws Exception {
+        var m = PlanetSearchProfile.class.getDeclaredMethod("flooredProminence", Float.class);
+        assertTrue(Modifier.isStatic(m.getModifiers()),
+                "flooredProminence is a build-time static in the Java indexer module");
+        assertEquals(float.class, m.getReturnType());
+        // FLOOR is the indexer-owned constant the insert path floors to.
+        assertEquals(0.05, ProminenceCalculator.FLOOR, 1e-9,
+                "the indexer owns the documented 0.05 prominence floor");
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/IsPlainTrailIconTest.java
+++ b/src/test/java/il/org/osm/israelhiking/IsPlainTrailIconTest.java
@@ -1,0 +1,36 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class IsPlainTrailIconTest {
+
+    @Test
+    public void plainTrailIconsAreSkipped() {
+        assertTrue(PlanetSearchProfile.isPlainTrailIcon("icon-hike"));
+        assertTrue(PlanetSearchProfile.isPlainTrailIcon("icon-bike"));
+        assertTrue(PlanetSearchProfile.isPlainTrailIcon("icon-four-by-four"));
+    }
+
+    @Test
+    public void nonTrailIconsAreEmitted() {
+        assertFalse(PlanetSearchProfile.isPlainTrailIcon("icon-peak"));
+        assertFalse(PlanetSearchProfile.isPlainTrailIcon("icon-river"));
+        assertFalse(PlanetSearchProfile.isPlainTrailIcon("icon-search"));
+        assertFalse(PlanetSearchProfile.isPlainTrailIcon(""));
+    }
+
+    @Test
+    public void nullIconIsEmitted() {
+        assertFalse(PlanetSearchProfile.isPlainTrailIcon(null));
+    }
+
+    @Test
+    public void valueEqualityNotReferenceEquality() {
+        assertTrue(PlanetSearchProfile.isPlainTrailIcon(new String("icon-hike")));
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/NormalizeAreaTest.java
+++ b/src/test/java/il/org/osm/israelhiking/NormalizeAreaTest.java
@@ -1,0 +1,34 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for PlanetSearchProfile.normalizeArea (the area -> [0,1] size proxy). */
+@Tag("unit")
+public class NormalizeAreaTest {
+
+    @Test
+    public void zeroAndNegativeAndNaNAreZero() {
+        assertEquals(0f, PlanetSearchProfile.normalizeArea(0));
+        assertEquals(0f, PlanetSearchProfile.normalizeArea(-100));
+        assertEquals(0f, PlanetSearchProfile.normalizeArea(Double.NaN));
+    }
+
+    @Test
+    public void outputIsClampedToUnitRange() {
+        // A huge area beyond the 1e11 cap saturates at 1.0 rather than exceeding it.
+        assertEquals(1f, PlanetSearchProfile.normalizeArea(1e15));
+        float mid = PlanetSearchProfile.normalizeArea(1_000_000);
+        assertTrue(mid > 0f && mid < 1f, "a finite area must land strictly inside (0,1)");
+    }
+
+    @Test
+    public void largerAreaScoresHigher() {
+        assertTrue(PlanetSearchProfile.normalizeArea(10_000_000)
+                > PlanetSearchProfile.normalizeArea(10_000),
+                "a bigger polygon must get a higher size proxy");
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/ParseFirstNumberTest.java
+++ b/src/test/java/il/org/osm/israelhiking/ParseFirstNumberTest.java
@@ -1,0 +1,247 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Defensive parsing of free-text OSM ele/population values. Must never throw; returns NaN when there
+ * is no usable number. A glued magnitude multiplier (k/K=1e3, M=1e6, B=1e9) rescales the digits.
+ */
+@Tag("unit")
+public class ParseFirstNumberTest {
+
+    private static double parse(String s) {
+        return OsmTagUtils.parseFirstNumber(s);
+    }
+
+    @Test
+    public void plainInteger() {
+        assertEquals(4302.0, parse("4302"), 1e-9);
+    }
+
+    @Test
+    public void decimal() {
+        assertEquals(4302.3, parse("4302.3"), 1e-9);
+    }
+
+    @Test
+    public void thousandsSeparatorComma() {
+        assertEquals(14115.0, parse("14,115"), 1e-9);
+    }
+
+    @Test
+    public void thousandsSeparatorSpace() {
+        assertEquals(1000.0, parse("1 000"), 1e-9);
+    }
+
+    @Test
+    public void numberWithUnitSuffix() {
+        assertEquals(14115.0, parse("14115 ft"), 1e-9);
+    }
+
+    @Test
+    public void yesIsNotANumber() {
+        assertTrue(Double.isNaN(parse("yes")));
+    }
+
+    @Test
+    public void nullIsNaN() {
+        assertTrue(Double.isNaN(parse(null)));
+    }
+
+    @Test
+    public void emptyIsNaN() {
+        assertTrue(Double.isNaN(parse("")));
+    }
+
+    @Test
+    public void rangeTakesFirstNumber() {
+        // "100-200" -> 100 (the hyphen ends the first number)
+        assertEquals(100.0, parse("100-200"), 1e-9);
+    }
+
+    @Test
+    public void secondDotEndsTheNumber() {
+        // A version-like "1.2.3": the first dot is the decimal point; the second dot (seenDot already
+        // true) is non-numeric and ends the number -> 1.2. Pins the seenDot guard's false arm.
+        assertEquals(1.2, parse("1.2.3"), 1e-9);
+        assertEquals(192.168, parse("192.168.0.1"), 1e-9);
+    }
+
+    @Test
+    public void pureNonNumericIsNaN() {
+        assertTrue(Double.isNaN(parse("abc")));
+    }
+
+    @Test
+    public void commaThousandsWithUnitSuffix() {
+        // "1,234 m" -> 1234.0 (comma stripped as thousands sep, " m" ends the number).
+        assertEquals(1234.0, parse("1,234 m"), 1e-9);
+    }
+
+    @Test
+    public void negativeElevation() {
+        // Below-sea-level elevations are real (Dead Sea region) — a leading '-' must be honored.
+        assertEquals(-413.0, parse("-413"), 1e-9);
+    }
+
+    @Test
+    public void negativeWithUnitSuffix() {
+        assertEquals(-413.0, parse("-413 m"), 1e-9);
+    }
+
+    @Test
+    public void loneMinusIsNaN() {
+        assertTrue(Double.isNaN(parse("-")));
+    }
+
+    @Test
+    public void minusThenNonNumericIsNaN() {
+        assertTrue(Double.isNaN(parse("-abc")));
+    }
+
+    // --- glued magnitude multipliers (the feature) --------------------------------
+
+    @Test
+    public void gluedMagnitudeSuffixMultiplies() {
+        // k/K=1e3, M=1e6, B=1e9. So population="1.5M" stores 1_500_000, not 1.
+        assertEquals(1_500_000.0, parse("1.5M"), 1e-9);
+        assertEquals(50_000.0, parse("50k"), 1e-9);
+        assertEquals(2_000_000.0, parse("2M"), 1e-9);
+        assertEquals(3_200.0, parse("3.2k"), 1e-9);
+        assertEquals(2_000_000_000.0, parse("2B"), 1e-9);
+        assertEquals(10_000.0, parse("10K"), 1e-9);
+    }
+
+    @Test
+    public void negativeWithMagnitudeSuffixMultiplies() {
+        assertEquals(-2_000_000.0, parse("-2M"), 1e-9);
+    }
+
+    @Test
+    public void multiplierEndsTheNumber_trailingCharsIgnored() {
+        // The first multiplier terminates the number; anything after it is discarded.
+        assertEquals(50_000.0, parse("50kk"), 1e-9);    // multiply once, stop
+        assertEquals(1_000_000.0, parse("1MM"), 1e-9);  // second M ignored
+        assertEquals(1_500.0, parse("1.5km"), 1e-9);    // 'k'->x1000, trailing 'm' ignored
+        assertEquals(1_500_000.0, parse("1.5M5"), 1e-9);
+        assertEquals(50_000.0, parse("50K100"), 1e-9);
+        assertEquals(1_000_000.0, parse("1.M"), 1e-9);  // "1." -> 1.0, then M
+    }
+
+    @Test
+    public void multiplierBeforeDigitsIsIgnored() {
+        // A magnitude letter is only a multiplier when glued AFTER a digit; leading ones are ignored.
+        assertEquals(50.0, parse("M50"), 1e-9);
+        assertEquals(50.0, parse("k50"), 1e-9);
+    }
+
+    @Test
+    public void onlyKkMbAreMultipliers_otherLettersAreTrailingUnits() {
+        assertEquals(1.5, parse("1.5G"), 1e-9);          // 'G' not in the set
+        assertEquals(1.0, parse("1b"), 1e-9);            // lowercase 'b' not recognized (only 'B')
+        assertEquals(1.0, parse("1g"), 1e-9);
+        assertEquals(1_000_000.0, parse("1Mb"), 1e-9);   // 'M' multiplies, trailing 'b' ignored
+    }
+
+    @Test
+    public void spaceSeparatedMagnitudeLetterDoesNotMultiply() {
+        // A magnitude letter after a separator/space/tab is a trailing token, not a glued suffix.
+        assertEquals(1.5, parse("1.5 M"), 1e-9);
+        assertEquals(1.5, parse("1.5 km"), 1e-9);
+        assertEquals(1.5, parse("1.5\tM"), 1e-9);
+    }
+
+    // --- lowercase 'm' is metres, never mega (protects elevations) ----------------
+
+    @Test
+    public void gluedMetresUnitStillParses() {
+        assertEquals(1500.0, parse("1500m"), 1e-9);
+        assertEquals(4302.0, parse("4302m"), 1e-9);
+        assertEquals(5.0, parse("5m"), 1e-9);
+        assertEquals(100.0, parse("100m2"), 1e-9);   // trailing unit + stray digit ignored
+        assertEquals(5.0, parse("5mi"), 1e-9);
+        assertEquals(1.5, parse("1.5mm"), 1e-9);
+    }
+
+    @Test
+    public void unitSeparatedBySpaceStillParses() {
+        assertEquals(14115.0, parse("14,115 ft"), 1e-9);
+        assertEquals(1200.0, parse("1200 m"), 1e-9);
+    }
+
+    // --- characterization: pin the exact behavior of unusual inputs ---------------
+    // Values captured by running the real parser. Some are deliberate quirks, others
+    // known limitations — each is labelled — so a future change can't silently shift them.
+
+    @ParameterizedTest(name = "\"{0}\" -> NaN")
+    @ValueSource(strings = {
+        " ", "  ", "--", "- ", "no", ".", "..", "-.", "k", "M", "kg",
+        "١٢٣"  // Arabic-Indic digits ١٢٣ — only ASCII 0-9 are recognized
+    })
+    public void variousNonNumbersAreNaN(String input) {
+        assertTrue(Double.isNaN(parse(input)), "expected NaN for \"" + input + "\"");
+    }
+
+    @Test
+    public void leadingZerosAndDotQuirks() {
+        assertEquals(0.0, parse("0"), 1e-9);
+        assertEquals(0.0, parse("00"), 1e-9);
+        assertEquals(7.0, parse("007"), 1e-9);   // leading zeros dropped by Double.parseDouble
+        assertEquals(5.0, parse("5."), 1e-9);    // trailing dot is harmless
+        assertEquals(5.0, parse(".5"), 1e-9);    // QUIRK: leading dot dropped, so ".5" == 5, NOT 0.5
+        assertEquals(0.0, parse("-0"), 1e-9);    // "-0" -> -0.0 (equal to 0.0 within delta)
+    }
+
+    @Test
+    public void separatorRunsAreSwallowed() {
+        assertEquals(1000.0, parse("1,000"), 1e-9);
+        assertEquals(1000.0, parse("1'000"), 1e-9);
+        assertEquals(1_234_567.0, parse("1,234,567"), 1e-9);
+        assertEquals(1_000_000.0, parse("1 000 000"), 1e-9);
+        assertEquals(1000.0, parse("1, 000"), 1e-9);   // comma+space run both swallowed
+        assertEquals(1000.0, parse("1,,000"), 1e-9);   // doubled comma swallowed
+        assertEquals(5.0, parse(",5"), 1e-9);          // leading comma (no digit yet) ignored
+        assertEquals(1.0, parse("1 "), 1e-9);
+    }
+
+    @Test
+    public void rangesAndTrailingPunctuation() {
+        assertEquals(1.0, parse("1-2-3"), 1e-9);
+        assertEquals(5.0, parse("5-"), 1e-9);
+        assertEquals(100.0, parse("100 - 200"), 1e-9);
+        assertEquals(1.5, parse("1.5-2.5M"), 1e-9);   // '-' ends the number before M applies
+    }
+
+    @Test
+    public void europeanDecimalCommaIsMisreadAsThousands() {
+        // KNOWN LIMITATION: comma is a thousands separator, so a European decimal "1,5M" becomes
+        // 15 then x1e6 = 15,000,000 (not 1,500,000). Pinned so the behavior is explicit.
+        assertEquals(15_000_000.0, parse("1,5M"), 1e-9);
+        assertEquals(15_000_000.0, parse("1 5M"), 1e-9);
+    }
+
+    @Test
+    public void onlyAsciiSpaceIsASeparator_nbspEndsTheNumber() {
+        // QUIRK: the separator test matches the ASCII space ' ' only. A non-breaking space (U+00A0)
+        // is NOT a separator — it ends the number, so the digits after it are lost.
+        assertEquals(5.0, parse("5 000"), 1e-9);   // NBSP -> only "5"
+        assertEquals(5000.0, parse("5 000"), 1e-9);     // contrast: ASCII space groups thousands
+    }
+
+    @Test
+    public void neverThrowsOnAdversarialInput() {
+        // The hard contract: parseFirstNumber must NEVER throw, whatever the input. (A huge digit
+        // run may parse to Infinity — that's a valid non-throwing result, not an error.)
+        String[] nasty = { null, "", "-", ".", "k", "M", "١٢٣", "1,,,M", "----",
+            "..M", "9".repeat(400), "-".repeat(50) + "5", "1.5 \tMkBx" };
+        for (String s : nasty) {
+            parse(s); // reaching the next line means it did not throw
+        }
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/PointsAnalyzerMappingTest.java
+++ b/src/test/java/il/org/osm/israelhiking/PointsAnalyzerMappingTest.java
@@ -1,0 +1,98 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.StringWriter;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
+import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesClient;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.endpoints.BooleanResponse;
+import co.elastic.clients.util.ObjectBuilder;
+import jakarta.json.stream.JsonGenerator;
+
+/**
+ * Asserts createPointsIndex emits the prefix and Hebrew-matres analyzers and wires the
+ * name.<lang>.prefix subfield. Captures the CreateIndexRequest the create(Function) overload builds
+ * and serializes it to JSON.
+ */
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+public class PointsAnalyzerMappingTest {
+
+    @Mock
+    private ElasticsearchClient esClient;
+
+    @Mock
+    private ElasticsearchIndicesClient indicesClient;
+
+    private final String[] supportedLanguages = { "en", "he", "ru", "ar", "es" };
+
+    @BeforeEach
+    void setUp() {
+        when(esClient.indices()).thenReturn(indicesClient);
+    }
+
+    private String createPointsIndexJson() throws Exception {
+        when(indicesClient.existsAlias(any(java.util.function.Function.class)))
+                .thenReturn(new BooleanResponse(false));
+        when(indicesClient.exists(any(java.util.function.Function.class)))
+                .thenReturn(new BooleanResponse(true));
+
+        ElasticsearchHelper.createPointsIndex(esClient, "points", supportedLanguages);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Function<CreateIndexRequest.Builder, ObjectBuilder<CreateIndexRequest>>> captor =
+                ArgumentCaptor.forClass(Function.class);
+        verify(indicesClient).create(captor.capture());
+
+        CreateIndexRequest request = captor.getValue()
+                .apply(new CreateIndexRequest.Builder())
+                .build();
+
+        JsonpMapper mapper = new JacksonJsonpMapper();
+        var sw = new StringWriter();
+        try (JsonGenerator gen = mapper.jsonProvider().createGenerator(sw)) {
+            request.serialize(gen, mapper);
+        }
+        return sw.toString();
+    }
+
+    @Test
+    public void declaresEdgeNgramPrefixSubfieldWithSplitAnalyzers() throws Exception {
+        var json = createPointsIndexJson();
+        assertTrue(json.contains("\"prefix\""), "name.<lang> must declare a .prefix subfield");
+        assertTrue(json.contains("prefix_index_analyzer"), "the .prefix index analyzer must be defined");
+        assertTrue(json.contains("prefix_search_analyzer"),
+                "the .prefix SEARCH analyzer (non-ngram) must be defined — the index/search split");
+        assertTrue(json.contains("edge_ngram_2_15"), "an edge_ngram token filter must be in the settings");
+    }
+
+    @Test
+    public void declaresHebrewMatresFiltersAndAnalyzers() throws Exception {
+        var json = createPointsIndexJson();
+        assertTrue(json.contains("hebrew_matres"), "the doubled-vav matres char_filter must be defined");
+        assertTrue(json.contains("hebrew_analyzer"), "a Hebrew-scoped analyzer must be defined");
+        assertTrue(json.contains("hebrew_normalizer"), "a Hebrew-scoped keyword normalizer must be defined");
+        assertTrue(json.contains("hebrew_prefix_index_analyzer"),
+                "the he-scoped prefix INDEX analyzer (matres + edge_ngram) must be defined");
+        assertTrue(json.contains("hebrew_prefix_search_analyzer"),
+                "the he-scoped prefix SEARCH analyzer (matres, no edge_ngram) must be defined");
+        // The shared universal analyzer still exists for non-Hebrew languages (blast-radius split).
+        assertTrue(json.contains("universal_analyzer"), "universal_analyzer must still exist");
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/PointsIndexMappingTest.java
+++ b/src/test/java/il/org/osm/israelhiking/PointsIndexMappingTest.java
@@ -1,0 +1,87 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.StringWriter;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
+import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesClient;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.endpoints.BooleanResponse;
+import co.elastic.clients.util.ObjectBuilder;
+import jakarta.json.stream.JsonGenerator;
+
+/**
+ * Asserts the computed ranking-signal fields are actually mapped by createPointsIndex. Captures the
+ * CreateIndexRequest built by the create(Function) convenience overload, serializes it to JSON, and
+ * checks the new fields are present so old documents (which omit them) keep working via missing:1.0.
+ */
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+public class PointsIndexMappingTest {
+
+    @Mock
+    private ElasticsearchClient esClient;
+
+    @Mock
+    private ElasticsearchIndicesClient indicesClient;
+
+    private final String[] supportedLanguages = { "en", "he", "ru", "ar", "es" };
+
+    @BeforeEach
+    void setUp() {
+        when(esClient.indices()).thenReturn(indicesClient);
+    }
+
+    private String createPointsIndexJson() throws Exception {
+        // No alias yet -> target is "<alias>1"; exists() true -> a delete is issued first.
+        when(indicesClient.existsAlias(any(java.util.function.Function.class)))
+                .thenReturn(new BooleanResponse(false));
+        when(indicesClient.exists(any(java.util.function.Function.class)))
+                .thenReturn(new BooleanResponse(true));
+
+        ElasticsearchHelper.createPointsIndex(esClient, "points", supportedLanguages);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Function<CreateIndexRequest.Builder, ObjectBuilder<CreateIndexRequest>>> captor =
+                ArgumentCaptor.forClass(Function.class);
+        verify(indicesClient).create(captor.capture());
+
+        CreateIndexRequest request = captor.getValue()
+                .apply(new CreateIndexRequest.Builder())
+                .build();
+
+        JsonpMapper mapper = new JacksonJsonpMapper();
+        var sw = new StringWriter();
+        try (JsonGenerator gen = mapper.jsonProvider().createGenerator(sw)) {
+            request.serialize(gen, mapper);
+        }
+        return sw.toString();
+    }
+
+    @Test
+    public void mappingDeclaresComputedRankingFields() throws Exception {
+        var json = createPointsIndexJson();
+        assertTrue(json.contains("poiProminence"), "poiProminence must be mapped");
+        assertTrue(json.contains("population"), "population must be mapped");
+        assertTrue(json.contains("poiFeatureClass"), "poiFeatureClass must be mapped");
+        assertTrue(json.contains("poiAreaNormalized"), "poiAreaNormalized must be mapped");
+        assertTrue(json.contains("intermittent"), "intermittent must be mapped");
+        // The primary name fields are untouched (additive change).
+        assertTrue(json.contains("name.default"), "name.<lang> primary fields must remain");
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/ProminenceCalculatorTest.java
+++ b/src/test/java/il/org/osm/israelhiking/ProminenceCalculatorTest.java
@@ -1,0 +1,144 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class ProminenceCalculatorTest {
+
+    private static final double NO_ELE = Double.NaN;
+
+    @Test
+    public void famousPeakWithQRankRanksHigh() {
+        // Pikes Peak: a ~4300m peak with a strong QRank signal and an image.
+        float prominence = ProminenceCalculator.compute("peak",
+                4302, /*image*/ true, /*website*/ false, /*wikidata*/ true, /*qrank*/ 359_540L);
+        assertTrue(prominence > 0.7, "famous high peak should score high, was " + prominence);
+    }
+
+    @Test
+    public void duplicateNodeWithNoSignalScoresLow() {
+        // The duplicate Pikes Peak node: same name, but no class, no ele, no wikidata/qrank.
+        // It gets only the floor + the generic-node baseline (0.05 + 0.45*0.25 = 0.1625) — far below
+        // a real classified/popular feature, which is what breaks the duplicate tie.
+        float prominence = ProminenceCalculator.compute(null, NO_ELE, false, false, false, 0L);
+        assertEquals(0.1625f, prominence, 1e-4, "a node with no signal should score at the baseline");
+
+        float famous = ProminenceCalculator.compute("peak", 4302, true, false, true, 359_540L);
+        assertTrue(famous > prominence * 3, "famous peak must dominate an unsignalled node");
+    }
+
+    @Test
+    public void prominenceIsNeverZero() {
+        // Floor guarantees a query-time multiply never annihilates a hit.
+        float prominence = ProminenceCalculator.compute(null, NO_ELE, false, false, false, 0L);
+        assertTrue(prominence >= ProminenceCalculator.FLOOR);
+        assertTrue(prominence > 0f);
+    }
+
+    @Test
+    public void cityOutranksVillage() {
+        float city = ProminenceCalculator.compute("city", NO_ELE, false, false, false, 0L);
+        float village = ProminenceCalculator.compute("village", NO_ELE, false, false, false, 0L);
+        assertTrue(city > village, "city " + city + " should outrank village " + village);
+    }
+
+    @Test
+    public void higherPeakOutranksLowerPeak() {
+        float high = ProminenceCalculator.compute("peak", 4000, false, false, false, 0L);
+        float low = ProminenceCalculator.compute("peak", 200, false, false, false, 0L);
+        assertTrue(high > low, "a 4000m peak should outrank a 200m hill");
+    }
+
+    @Test
+    public void parkScoresAboveGenericNode() {
+        // national_park/protected_area are classified as "park" by classifyFeatureClass.
+        float park = ProminenceCalculator.compute("park", NO_ELE, false, false, false, 0L);
+        float generic = ProminenceCalculator.compute(null, NO_ELE, false, false, false, 0L);
+        assertTrue(park > generic);
+    }
+
+    @Test
+    public void qrankOnlyCountsWithRawAboveOne() {
+        // A raw QRank > 1 lifts the score; a 0/1 raw value contributes nothing — proven by the two
+        // scores being equal when only the (<=1) qrank input differs.
+        float withQ = ProminenceCalculator.compute("spring", NO_ELE, false, false, true, 50_000L);
+        float noQ = ProminenceCalculator.compute("spring", NO_ELE, false, false, true, 0L);
+        float oneQ = ProminenceCalculator.compute("spring", NO_ELE, false, false, true, 1L);
+        assertTrue(withQ > noQ, "a popular spring should beat an obscure one");
+        assertEquals(noQ, oneQ, 1e-6, "a raw QRank of 1 contributes nothing, same as 0");
+    }
+
+    @Test
+    public void negativeElevationScoresLikeSeaLevel() {
+        // Dead Sea-region peaks sit below sea level (ele < 0). The elevation is floored at 0 so log1p
+        // never sees a negative argument (which would yield NaN). A below-sea-level peak then scores
+        // identically to a sea-level peak — proving the clamp without reading an internal component.
+        float below = ProminenceCalculator.compute("peak", -413, false, false, false, 0L);
+        float atSea = ProminenceCalculator.compute("peak", 0, false, false, false, 0L);
+        assertEquals(atSea, below, 1e-6, "a below-sea-level peak should score like a sea-level peak");
+        assertTrue(below > 0f && below <= 1f, "prominence must stay finite and in range, was " + below);
+    }
+
+    @Test
+    public void outputAlwaysInUnitRange() {
+        // Even maxed-out inputs (top-prior class + max ele/qrank + all richness) stay clamped to [0,1].
+        float prominence = ProminenceCalculator.compute("city", 8849, true, true, true, Long.MAX_VALUE);
+        assertTrue(prominence >= 0f && prominence <= 1f, "prominence out of range: " + prominence);
+    }
+
+    /** Bare base-prior contribution for a class with no other signal: FLOOR + 0.45*prior. */
+    private static float bare(String featureClass) {
+        return ProminenceCalculator.compute(featureClass, NO_ELE, false, false, false, 0L);
+    }
+
+    @Test
+    public void settlementPriorsAreOrdered() {
+        // city(1.00) > town(0.80) > village(0.55) > hamlet(0.35) > generic(0.25).
+        assertTrue(bare("town") > bare("village"), "town must outrank village");
+        assertTrue(bare("village") > bare("hamlet"), "village must outrank hamlet");
+        assertTrue(bare("hamlet") > bare(null), "hamlet must outrank an unclassified node");
+        // exact floored values pin the town (0.80) and hamlet (0.35) arms.
+        assertEquals(0.05f + 0.45f * 0.80f, bare("town"), 1e-5f);
+        assertEquals(0.05f + 0.45f * 0.35f, bare("hamlet"), 1e-5f);
+    }
+
+    @Test
+    public void midTierPlaceClassesShareThe045Prior() {
+        // suburb/neighbourhood/island/locality/place all map to the 0.45 prior arm.
+        float expected = 0.05f + 0.45f * 0.45f;
+        for (String fc : new String[] {"suburb", "neighbourhood", "island", "locality", "place"}) {
+            assertEquals(expected, bare(fc), 1e-5f, fc + " should use the 0.45 prior");
+        }
+    }
+
+    @Test
+    public void poiAndHistoricClassesShareThe055Prior() {
+        // viewpoint/attraction/lodging/historic all map to the 0.55 prior arm.
+        float expected = 0.05f + 0.45f * 0.55f;
+        for (String fc : new String[] {"viewpoint", "attraction", "lodging", "historic"}) {
+            assertEquals(expected, bare(fc), 1e-5f, fc + " should use the 0.55 prior");
+        }
+    }
+
+    @Test
+    public void clamp01HandlesNanNegativeAndOverflow() {
+        // clamp01 is the last line of defence before the score reaches ES: NaN -> 0 (never poisons the
+        // multiply), negatives -> 0, >1 -> 1, in-range passes through.
+        assertEquals(0.0, ProminenceCalculator.clamp01(Double.NaN), 0.0, "NaN must clamp to 0");
+        assertEquals(0.0, ProminenceCalculator.clamp01(-0.5), 0.0, "negative must clamp to 0");
+        assertEquals(1.0, ProminenceCalculator.clamp01(1.7), 0.0, "above 1 must clamp to 1");
+        assertEquals(0.42, ProminenceCalculator.clamp01(0.42), 1e-9, "in-range value passes through");
+    }
+
+    @Test
+    public void unknownClassUsesTheDefaultPrior() {
+        // An unrecognised feature_class falls to the 0.25 default arm — same as a null class.
+        assertEquals(bare(null), bare("zzz-unknown-class"), 1e-6f,
+                "an unknown class should score at the generic 0.25 prior, like null");
+        assertEquals(0.05f + 0.45f * 0.25f, bare("zzz-unknown-class"), 1e-5f);
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/QRankIndexTest.java
+++ b/src/test/java/il/org/osm/israelhiking/QRankIndexTest.java
@@ -1,0 +1,207 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.GZIPOutputStream;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("unit")
+public class QRankIndexTest {
+
+    @Test
+    public void emptyIndexReturnsZero() {
+        var idx = QRankIndex.empty();
+        assertEquals(0, idx.getByWikidata("Q665321"));
+        assertEquals(0, idx.size());
+    }
+
+    @Test
+    public void nullPathYieldsEmptyIndexNoException() {
+        var idx = QRankIndex.load(null);
+        assertEquals(0, idx.size());
+        assertEquals(0, idx.getByWikidata("Q42"));
+    }
+
+    @Test
+    public void missingFileYieldsEmptyIndex(@TempDir Path dir) {
+        var idx = QRankIndex.load(dir.resolve("does-not-exist.csv.gz"));
+        assertEquals(0, idx.size());
+    }
+
+    @Test
+    public void parsesGzippedCsvAndLooksUpByWikidata(@TempDir Path dir) throws IOException {
+        Path gz = dir.resolve("qrank.csv.gz");
+        try (OutputStream os = Files.newOutputStream(gz);
+                GZIPOutputStream gzos = new GZIPOutputStream(os)) {
+            gzos.write("Entity,QRank\nQ665321,359540\nQ121211166,34\nQ42,1000000\n"
+                    .getBytes(StandardCharsets.UTF_8));
+        }
+        var idx = QRankIndex.load(gz);
+        assertEquals(3, idx.size());
+        assertEquals(359540, idx.getByWikidata("Q665321"));
+        assertEquals(34, idx.getByWikidata("Q121211166"));
+        assertEquals(1000000, idx.getByWikidata("Q42"));
+    }
+
+    @Test
+    public void skipsMalformedRowsWithoutFailing(@TempDir Path dir) throws IOException {
+        // Rows that fail the comma<=1 guard or the non-numeric parse must be skipped, never throw,
+        // and never inflate the row count. Only the two well-formed rows survive.
+        Path gz = dir.resolve("qrank.csv.gz");
+        try (OutputStream os = Files.newOutputStream(gz);
+                GZIPOutputStream gzos = new GZIPOutputStream(os)) {
+            gzos.write(("Entity,QRank\n"
+                    + "Q,100\n"        // comma at index 1 -> comma <= 1, skipped
+                    + ",100\n"         // comma at index 0 -> comma <= 1, skipped
+                    + "A,123\n"        // does not start with 'Q', skipped
+                    + "Q42,abc\n"      // well-formed prefix but non-numeric rank -> NumberFormatException, skipped
+                    + "Q665321,359540\n"
+                    + "Q1,5\n")
+                    .getBytes(StandardCharsets.UTF_8));
+        }
+        var idx = QRankIndex.load(gz);
+        assertEquals(2, idx.size(), "only the two well-formed Q-rows should load");
+        assertEquals(359540, idx.getByWikidata("Q665321"));
+        assertEquals(5, idx.getByWikidata("Q1"));
+        assertEquals(0, idx.getByWikidata("Q42"), "row with non-numeric rank was skipped");
+    }
+
+    @Test
+    public void rowWithoutCommaIsSkipped(@TempDir Path dir) throws IOException {
+        // A line with no comma -> split(",",2) yields a single column -> cols.length != 2 -> skipped.
+        // Pins the first sub-clause of the load-time guard, distinct from the length<2/non-Q clauses.
+        Path gz = dir.resolve("qrank.csv.gz");
+        try (OutputStream os = Files.newOutputStream(gz);
+                GZIPOutputStream gzos = new GZIPOutputStream(os)) {
+            gzos.write(("Entity,QRank\n"
+                    + "Q665321\n"        // no comma -> one column -> cols.length != 2, skipped
+                    + "Q42,1000000\n")
+                    .getBytes(StandardCharsets.UTF_8));
+        }
+        var idx = QRankIndex.load(gz);
+        assertEquals(1, idx.size(), "the comma-less row is skipped; only the valid row loads");
+        assertEquals(0, idx.getByWikidata("Q665321"), "comma-less row never indexed");
+        assertEquals(1000000, idx.getByWikidata("Q42"));
+    }
+
+    @Test
+    public void longNonQPrefixedRowIsSkipped(@TempDir Path dir) throws IOException {
+        // cols[0] of length >= 2 that does NOT start with 'Q' (e.g. "AB") must be skipped: this hits
+        // the charAt(0) != 'Q' sub-clause specifically, which the length<2 rows short-circuit past.
+        Path gz = dir.resolve("qrank.csv.gz");
+        try (OutputStream os = Files.newOutputStream(gz);
+                GZIPOutputStream gzos = new GZIPOutputStream(os)) {
+            gzos.write(("Entity,QRank\n"
+                    + "AB,999\n"          // length>=2 but not Q-prefixed -> charAt(0)!='Q', skipped
+                    + "Q42,1000000\n")
+                    .getBytes(StandardCharsets.UTF_8));
+        }
+        var idx = QRankIndex.load(gz);
+        assertEquals(1, idx.size(), "the non-Q-prefixed row is skipped; only the valid row loads");
+        assertEquals(1000000, idx.getByWikidata("Q42"));
+    }
+
+    @Test
+    public void corruptGzipYieldsEmptyIndexNoException(@TempDir Path dir) throws IOException {
+        // A file that is not valid gzip must not fail the build: load() catches, logs, and returns
+        // whatever loaded (here nothing). The .gz extension lures the reader past the regular-file guard.
+        Path gz = dir.resolve("qrank.csv.gz");
+        Files.write(gz, "this is not gzip".getBytes(StandardCharsets.UTF_8));
+        var idx = QRankIndex.load(gz);
+        assertEquals(0, idx.size(), "an unreadable file should yield an empty index, not throw");
+        assertEquals(0, idx.getByWikidata("Q42"));
+    }
+
+    @Test
+    public void unknownOrMalformedWikidataReturnsZero(@TempDir Path dir) throws IOException {
+        Path gz = dir.resolve("qrank.csv.gz");
+        try (OutputStream os = Files.newOutputStream(gz);
+                GZIPOutputStream gzos = new GZIPOutputStream(os)) {
+            gzos.write("Entity,QRank\nQ1,5\n".getBytes(StandardCharsets.UTF_8));
+        }
+        var idx = QRankIndex.load(gz);
+        assertEquals(0, idx.getByWikidata("Q999"), "unknown id -> 0");
+        assertEquals(0, idx.getByWikidata(null), "null -> 0");
+        assertEquals(0, idx.getByWikidata(""), "empty -> 0");
+        assertEquals(0, idx.getByWikidata("notaqid"), "malformed -> 0");
+        assertTrue(idx.getByWikidata("Q1") > 0);
+    }
+
+    /** Build a gz index from "Q1,5\nQ42,1000000\n..." style lines (header prepended). */
+    private static QRankIndex indexOf(Path dir, String rows) throws IOException {
+        Path gz = dir.resolve("qrank.csv.gz");
+        try (OutputStream os = Files.newOutputStream(gz);
+                GZIPOutputStream gzos = new GZIPOutputStream(os)) {
+            gzos.write(("Entity,QRank\n" + rows).getBytes(StandardCharsets.UTF_8));
+        }
+        return QRankIndex.load(gz);
+    }
+
+    @Test
+    public void multiValueTakesMaxQRank(@TempDir Path dir) throws IOException {
+        // Q42;Q64 -> max QRank wins, regardless of order.
+        var idx = indexOf(dir, "Q42,1000000\nQ64,5\n");
+        assertEquals(1000000, idx.getByWikidata("Q42;Q64"));
+        assertEquals(1000000, idx.getByWikidata("Q64;Q42"));
+    }
+
+    @Test
+    public void multiValueSkipsUnknownParts(@TempDir Path dir) throws IOException {
+        var idx = indexOf(dir, "Q64,5\n");
+        assertEquals(5, idx.getByWikidata("Q999;Q64"), "unknown part contributes 0, known part wins");
+    }
+
+    @Test
+    public void whitespaceIsTrimmed(@TempDir Path dir) throws IOException {
+        var idx = indexOf(dir, "Q42,1000000\nQ64,5\n");
+        assertEquals(1000000, idx.getByWikidata(" Q42 "));
+        assertEquals(1000000, idx.getByWikidata("Q42; Q64"), "space after the separator is trimmed");
+    }
+
+    @Test
+    public void lowercaseQAccepted(@TempDir Path dir) throws IOException {
+        var idx = indexOf(dir, "Q42,1000000\n");
+        assertEquals(1000000, idx.getByWikidata("q42"));
+    }
+
+    @Test
+    public void multiValueAllMalformedReturnsZero(@TempDir Path dir) throws IOException {
+        var idx = indexOf(dir, "Q42,1000000\n");
+        assertEquals(0, idx.getByWikidata("Q999;foo;"), "all parts unknown/malformed -> 0");
+        assertEquals(0, idx.getByWikidata(";"));
+        assertEquals(0, idx.getByWikidata("Q;Q"));
+    }
+
+    @Test
+    public void wellPrefixedButNonNumericQidReturnsZero(@TempDir Path dir) throws IOException {
+        // "Qabc" passes the length>=2 and leading-Q guard, then fails Long.parseLong inside qrankFor:
+        // the lookup-side catch must swallow it and return 0, never throw. A valid sibling still wins.
+        var idx = indexOf(dir, "Q42,1000000\n");
+        assertEquals(0, idx.getByWikidata("Qabc"), "non-numeric Q-id must be caught and yield 0");
+        assertEquals(0, idx.getByWikidata("Q12x"), "trailing non-digit must be caught and yield 0");
+        assertEquals(1000000, idx.getByWikidata("Qabc;Q42"),
+                "an unparseable part contributes 0; the valid part still wins");
+    }
+
+    @Test
+    public void multiValueSeparatorEdgePositions(@TempDir Path dir) throws IOException {
+        // The manual indexOf-walk differs from String.split() exactly at trailing/leading/double
+        // separators (split drops trailing empties; the walk visits the empty tail). A valid Q-id
+        // must still be found regardless of where empty parts sit around it.
+        var idx = indexOf(dir, "Q42,1000000\nQ64,5\n");
+        assertEquals(1000000, idx.getByWikidata("Q42;"), "trailing separator: valid part still found");
+        assertEquals(1000000, idx.getByWikidata(";Q42"), "leading separator: empty first part skipped");
+        assertEquals(1000000, idx.getByWikidata("Q42;;Q64"), "double separator: empty middle part skipped");
+        assertEquals(1000000, idx.getByWikidata("Q42 ; Q64"), "spaces on both sides of the separator");
+        assertEquals(1000000, idx.getByWikidata("Q999;Q42;"), "unknown + valid + empty trailing");
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/SetFeatureClassTest.java
+++ b/src/test/java/il/org/osm/israelhiking/SetFeatureClassTest.java
@@ -1,0 +1,283 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the OSM-tag -> feature_class classifier (classifyFeatureClass). Pins the landform
+ * vocabulary expansion (canyon/gorge/mesa/plateau/arch/cave/wetland and the
+ * arete/crater/mountain_range folds) and guards the pre-existing mappings against regression.
+ * Doc-side classes here must each have a class_groups entry in updated_score.yml, or the query-time
+ * pclass boost is a silent no-op.
+ */
+@Tag("unit")
+public class SetFeatureClassTest {
+
+    private static Function<String, String> tags(Map<String, String> m) {
+        return m::get;
+    }
+
+    private static String classify(Map<String, String> m) {
+        return OsmTagUtils.classifyFeatureClass(tags(m));
+    }
+
+    // --- new landform classes ------------------------------------------------
+
+    @Test
+    public void canyonAndGorgeMapToCanyon() {
+        assertEquals("canyon", classify(Map.of("natural", "canyon")));
+        assertEquals("canyon", classify(Map.of("natural", "gorge")));
+    }
+
+    @Test
+    public void mesaAndPlateauMapToPlateau() {
+        assertEquals("plateau", classify(Map.of("natural", "mesa")));
+        assertEquals("plateau", classify(Map.of("natural", "plateau")));
+    }
+
+    @Test
+    public void archCaveAndWetlandGetTheirOwnClass() {
+        assertEquals("arch", classify(Map.of("natural", "arch")));
+        assertEquals("cave", classify(Map.of("natural", "cave_entrance")));
+        assertEquals("wetland", classify(Map.of("natural", "wetland")));
+    }
+
+    @Test
+    public void areteCraterAndRangeFoldToExistingClasses() {
+        assertEquals("ridge", classify(Map.of("natural", "arete")));
+        assertEquals("peak", classify(Map.of("natural", "crater")));
+        assertEquals("peak", classify(Map.of("natural", "mountain_range")));
+    }
+
+    // --- regression guards on pre-existing mappings --------------------------
+
+    @Test
+    public void valleyIsUnchanged() {
+        assertEquals("valley", classify(Map.of("natural", "valley")));
+    }
+
+    @Test
+    public void peakVolcanoAndWaterRefinementUnchanged() {
+        assertEquals("peak", classify(Map.of("natural", "peak")));
+        assertEquals("peak", classify(Map.of("natural", "volcano")));
+        assertEquals("reservoir", classify(Map.of("natural", "water", "water", "reservoir")));
+        assertEquals("lake", classify(Map.of("natural", "water")));
+    }
+
+    @Test
+    public void waterRiverAndCanalAreNotMislabelledAsLake() {
+        // natural=water + water=river|canal are common (wide-river / canal surfaces); they must not
+        // be classified as lakes. Unknown sub-types get the neutral "water", never "lake".
+        assertEquals("river", classify(Map.of("natural", "water", "water", "river")));
+        assertEquals("canal", classify(Map.of("natural", "water", "water", "canal")));
+        assertEquals("lagoon", classify(Map.of("natural", "water", "water", "lagoon")));
+        assertEquals("water", classify(Map.of("natural", "water", "water", "oxbow")));
+        // lake/reservoir/pond and the no-subtype base case stay as before.
+        assertEquals("lake", classify(Map.of("natural", "water", "water", "lake")));
+        assertEquals("reservoir", classify(Map.of("natural", "water", "water", "reservoir")));
+        assertEquals("pond", classify(Map.of("natural", "water", "water", "pond")));
+        assertEquals("lake", classify(Map.of("natural", "water")));
+    }
+
+    @Test
+    public void unrecognisedNaturalFallsBackToNaturalCatchAll() {
+        // sand/dune/basin/... deliberately stay in the generic catch-all (OUTDOOR_GENERIC group).
+        assertEquals("natural", classify(Map.of("natural", "sand")));
+    }
+
+    // --- non-natural primary tags --------------------------------------------
+
+    @Test
+    public void railwayAndLanduseStayNull() {
+        // railway/landuse carry no classified primary type tag, so they stay null (no spurious
+        // class). Note: railway=station is intentionally NOT classified — it reaches the index via
+        // a poiIcon path, but feature_class folds station handling under building=train_station.
+        assertNull(classify(Map.of("railway", "station")));
+        assertNull(classify(Map.of("landuse", "forest")));
+    }
+
+    // --- built / POI classes --------------------------------------
+
+    @Test
+    public void lodgingTourismMapsToLodging() {
+        assertEquals("lodging", classify(Map.of("tourism", "hotel")));
+        assertEquals("lodging", classify(Map.of("tourism", "guest_house")));
+        assertEquals("museum", classify(Map.of("tourism", "museum")));
+        // pre-existing tourism mappings unchanged
+        assertEquals("viewpoint", classify(Map.of("tourism", "viewpoint")));
+        assertEquals("campsite", classify(Map.of("tourism", "camp_site")));
+    }
+
+    @Test
+    public void amenityMapsToPoiClasses() {
+        assertEquals("food", classify(Map.of("amenity", "restaurant")));
+        assertEquals("food", classify(Map.of("amenity", "cafe")));
+        assertEquals("religious", classify(Map.of("amenity", "place_of_worship")));
+        assertEquals("education", classify(Map.of("amenity", "school")));
+        assertEquals("medical", classify(Map.of("amenity", "pharmacy")));
+        assertEquals("government", classify(Map.of("amenity", "townhall")));
+        assertEquals("parking", classify(Map.of("amenity", "parking")));
+        assertEquals("fuel", classify(Map.of("amenity", "fuel")));
+        // unrecognised amenity falls back to the amenity catch-all (BUILT_GENERIC group)
+        assertEquals("amenity", classify(Map.of("amenity", "bench")));
+    }
+
+    @Test
+    public void leisureShopOfficeHealthcareMapped() {
+        assertEquals("park", classify(Map.of("leisure", "park")));
+        assertEquals("park", classify(Map.of("leisure", "nature_reserve")));
+        assertEquals("sports", classify(Map.of("leisure", "sports_centre")));
+        assertEquals("shop", classify(Map.of("shop", "supermarket")));
+        assertEquals("office", classify(Map.of("office", "lawyer")));
+        assertEquals("medical", classify(Map.of("healthcare", "clinic")));
+    }
+
+    @Test
+    public void manMadeAndBuildingMapped() {
+        assertEquals("structure", classify(Map.of("man_made", "lighthouse")));
+        assertEquals("man_made", classify(Map.of("man_made", "antenna")));
+        assertEquals("religious", classify(Map.of("building", "church")));
+        assertEquals("transit", classify(Map.of("building", "train_station")));
+        // a named generic building gets the generic class, not null
+        assertEquals("building", classify(Map.of("building", "yes")));
+        assertEquals("building", classify(Map.of("building", "hall")));
+        // building=no/none never classifies
+        assertNull(classify(Map.of("building", "no")));
+        assertNull(classify(Map.of("building", "none")));
+    }
+
+    @Test
+    public void outdoorWinsOverBuiltTags() {
+        // priority order: natural > waterway > place > historic > tourism > built/POI keys.
+        // A viewpoint that is also a building stays a viewpoint; a peak that is also amenity stays peak.
+        assertEquals("viewpoint", classify(Map.of("tourism", "viewpoint", "building", "yes")));
+        assertEquals("peak", classify(Map.of("natural", "peak", "amenity", "restaurant")));
+        assertEquals("lake", classify(Map.of("natural", "water", "leisure", "park")));
+    }
+
+    @Test
+    public void naturalWinsOverOtherPrimaryTags() {
+        // priority order: natural > waterway > place > historic > tourism
+        assertEquals("canyon", classify(Map.of("natural", "canyon", "place", "locality")));
+    }
+
+    @Test
+    public void noTagsYieldsNull() {
+        assertNull(classify(Map.of("name", "Anonymous")));
+    }
+
+    @Test
+    public void nullTagLookupResultYieldsNull() {
+        // Every primary key absent -> classifier returns null (the absent-feature guard).
+        assertNull(OsmTagUtils.classifyFeatureClass(t -> null));
+    }
+
+    // --- remaining natural sub-types (one assertion per uncovered switch arm) -
+
+    @Test
+    public void naturalLandformArmsClassified() {
+        assertEquals("hill", classify(Map.of("natural", "hill")));
+        assertEquals("ridge", classify(Map.of("natural", "ridge")));
+        assertEquals("saddle", classify(Map.of("natural", "saddle")));
+        assertEquals("saddle", classify(Map.of("natural", "gap")));
+        assertEquals("cliff", classify(Map.of("natural", "cliff")));
+        assertEquals("rock", classify(Map.of("natural", "rock")));
+        assertEquals("rock", classify(Map.of("natural", "stone")));
+        assertEquals("glacier", classify(Map.of("natural", "glacier")));
+        assertEquals("bay", classify(Map.of("natural", "bay")));
+        assertEquals("cape", classify(Map.of("natural", "cape")));
+        assertEquals("beach", classify(Map.of("natural", "beach")));
+        assertEquals("forest", classify(Map.of("natural", "wood")));
+        assertEquals("forest", classify(Map.of("natural", "forest")));
+    }
+
+    @Test
+    public void naturalSpringArmsClassified() {
+        assertEquals("spring", classify(Map.of("natural", "spring")));
+        assertEquals("spring", classify(Map.of("natural", "hot_spring")));
+    }
+
+    // --- waterway sub-types ---------------------------------------------------
+
+    @Test
+    public void waterwaySubtypesClassified() {
+        assertEquals("waterfall", classify(Map.of("waterway", "waterfall")));
+        assertEquals("river", classify(Map.of("waterway", "river")));
+        assertEquals("stream", classify(Map.of("waterway", "stream")));
+        assertEquals("canal", classify(Map.of("waterway", "canal")));
+        assertEquals("rapids", classify(Map.of("waterway", "rapids")));
+        // unknown waterway falls back to the generic "waterway" class
+        assertEquals("waterway", classify(Map.of("waterway", "drain")));
+    }
+
+    // --- place sub-types ------------------------------------------------------
+
+    @Test
+    public void placeSubtypesClassified() {
+        // city/town/village/hamlet/suburb/neighbourhood pass through as their own value
+        assertEquals("city", classify(Map.of("place", "city")));
+        assertEquals("hamlet", classify(Map.of("place", "hamlet")));
+        assertEquals("suburb", classify(Map.of("place", "suburb")));
+        assertEquals("neighbourhood", classify(Map.of("place", "neighbourhood")));
+        assertEquals("island", classify(Map.of("place", "island")));
+        assertEquals("island", classify(Map.of("place", "islet")));
+        assertEquals("locality", classify(Map.of("place", "locality")));
+        // unknown place falls back to the generic "place" class
+        assertEquals("place", classify(Map.of("place", "county")));
+    }
+
+    // --- historic / tourism / leisure / craft ---------------------------------
+
+    @Test
+    public void historicAlwaysMapsToHistoric() {
+        assertEquals("historic", classify(Map.of("historic", "castle")));
+        assertEquals("historic", classify(Map.of("historic", "ruins")));
+    }
+
+    @Test
+    public void tourismRemainingArmsClassified() {
+        assertEquals("attraction", classify(Map.of("tourism", "attraction")));
+        // information folds into the generic "tourism" class
+        assertEquals("tourism", classify(Map.of("tourism", "information")));
+        // unknown tourism falls back to "tourism"
+        assertEquals("tourism", classify(Map.of("tourism", "zoo")));
+    }
+
+    @Test
+    public void leisureUnknownFallsBackToLeisure() {
+        assertEquals("leisure", classify(Map.of("leisure", "marina")));
+    }
+
+    @Test
+    public void amenityTransitAndArtsArmsClassified() {
+        assertEquals("transit", classify(Map.of("amenity", "bus_station")));
+        assertEquals("museum", classify(Map.of("amenity", "theatre")));
+    }
+
+    @Test
+    public void craftMapsToOffice() {
+        // craft is the only primary key (so the else-if craft arm is exercised) -> "office".
+        assertEquals("office", classify(Map.of("craft", "carpenter")));
+    }
+
+    // --- building guard + remaining building sub-types ------------------------
+
+    @Test
+    public void buildingCapitalNoIsNotClassified() {
+        // The guard rejects "no"/"none"/"No"; capital-N "No" must also yield null, not "building".
+        assertNull(classify(Map.of("building", "No")));
+    }
+
+    @Test
+    public void buildingRemainingSubtypesClassified() {
+        assertEquals("lodging", classify(Map.of("building", "hotel")));
+        assertEquals("medical", classify(Map.of("building", "hospital")));
+        assertEquals("education", classify(Map.of("building", "school")));
+    }
+}


### PR DESCRIPTION
## What

Adds the build-time signals the query-side ranking reads. Every field is additive: an absent field falls back to Elasticsearch `missing:1.0`, so existing queries keep working.

- `OsmTagUtils`: pure tag helpers - `parseFirstNumber`, `classifyFeatureClass` (coarse feature type), `buildAltNames` (variant names), `computePopulation` (settlement ladder with an overflow guard).
- `PointDocument` and mapping: `poiProminence`, `poiAreaNormalized`, `intermittent`, `population`, `poiFeatureClass`, `alt_names`; `@JsonInclude(NON_NULL)`.
- Analyzers: an edge-ngram `name.<lang>.prefix` subfield for as-you-type recall, and a Hebrew doubled-matres fold on `name.he`.
- `ProminenceCalculator` and `QRankIndex`: a composite [0,1] prominence from a feature-class prior, elevation, Wikimedia QRank and metadata richness, floored so a query-time multiply never zeroes a hit. The prior keys off `poiFeatureClass` (the single `classifyFeatureClass` mapping), not raw tags. QRank loads from an optional `--qrank-path` (empty means lookups return 0).
- Every emit path, including the non-icon path, routes through `convertTagsToDocument`, so all features carry the signals.

## One intended behavior change: Hebrew

`name.he` moves to a `hebrew_analyzer` that folds doubled matres (a doubled vav to a single vav, a doubled yod to a single yod; single letters are never dropped). Hebrew searches now match spelling variants they previously missed. This pairs with the Site `query_norm`; both halves must deploy together.

## New OSM tag support

The classifier recognizes tag values the index did not surface before (volcano, canyon, plateau, arch, cave, wetland and more), `boundary=national_park|protected_area`, and variant-name tags. The Site repo must be updated to consume the new fields and values for ranking.

## Tests

`ParseFirstNumber`, `SetFeatureClass`, `AddAltNames`, `ComputePopulation`, `HebrewMatresRule`, `PointsIndexMapping`, `PointsAnalyzerMapping`, `ProminenceCalculator`, `InsertProminenceFloor`, `QRankIndex`, `NormalizeArea`. All 125 unit tests pass.

## Review notes addressed (from #63)

- Prefix computed (non-OSM) fields with `poi`, and use `poiFeatureClass` rather than `feature_class`: done.
- Rename `poiAreaNorm` to `poiAreaNormalized`: done.
- Simplify the QRank parsing (use split, not manual indexing): `load` parses the two-column CSV with `split`, and `getByWikidata` splits a multi-value tag and streams to the max rank.
- Explain the 32M capacity hint: it is a hint to avoid rehashing during load; the map grows for a larger file.
- Is wikidata counted twice: documented; wikidata as a richness flag and wikidata as the QRank key are intentionally separate.
- Remove `baseScore` and keep icon/feature_class/ranking together: the prominence prior now keys off `poiFeatureClass` instead of re-deriving from raw tags, so the three flows share one source of truth.
- Add `--qrank-path` usage to the README: done, with a download and run example.
- Comments too verbose, no HTML, no ADR references: aggressive comment sweep across the new files.

Part of splitting #63 into small, independent, non-breaking increments. Companion PRs: indexer resilience, volcano icon, `--skip-tiles`.
