### PR TITLE
Add prefix and Hebrew-matres analyzers for the points index

### DIFF
--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -15,6 +15,22 @@ import co.elastic.clients.transport.rest_client.RestClientTransport;
 
 public class ElasticsearchHelper {
 
+  // Doubled-only: folding a single vav/yod would merge real homographs. "\\u" reaches ES as the literal Lucene escape.
+  static final String HEBREW_VAV = "ו";
+  static final String HEBREW_YOD = "י";
+  static final String HEBREW_DOUBLED_VAV_PATTERN = "\\u05D5\\u05D5";
+  static final String HEBREW_DOUBLED_YOD_PATTERN = "\\u05D9\\u05D9";
+
+  /** Reference implementation of the doubled-only matres fold, so a unit test can assert it without a live ES. */
+  static String applyHebrewMatresDoubledOnly(String input) {
+    if (input == null) {
+      return null;
+    }
+    return input
+        .replaceAll("וו", HEBREW_VAV)
+        .replaceAll("יי", HEBREW_YOD);
+  }
+
   public static record ElasticRunContext(
       ElasticsearchClient esClient,
       String pointsIndexAlias,
@@ -53,29 +69,80 @@ public class ElasticsearchHelper {
                         .patternReplace(pr -> pr
                             .pattern("[\\u05B0-\\u05C7]")
                             .replacement(""))))
+                .charFilter("hebrew_matres", cf -> cf
+                    .definition(d -> d
+                        .patternReplace(pr -> pr
+                            .pattern(HEBREW_DOUBLED_VAV_PATTERN)
+                            .replacement(HEBREW_VAV))))
+                .charFilter("hebrew_matres_yod", cf -> cf
+                    .definition(d -> d
+                        .patternReplace(pr -> pr
+                            .pattern(HEBREW_DOUBLED_YOD_PATTERN)
+                            .replacement(HEBREW_YOD))))
+                .filter("edge_ngram_2_15", tf -> tf
+                    .definition(d -> d
+                        .edgeNgram(en -> en.minGram(2).maxGram(15))))
                 .normalizer("universal_normalizer", n -> n
                     .custom(cn -> cn
                         .charFilter("hebrew_niqqud")
+                        .filter("asciifolding", "lowercase")))
+                .normalizer("hebrew_normalizer", n -> n
+                    .custom(cn -> cn
+                        .charFilter("hebrew_niqqud", "hebrew_matres", "hebrew_matres_yod")
                         .filter("asciifolding", "lowercase")))
                 .analyzer("universal_analyzer", an -> an
                     .custom(ca -> ca
                         .charFilter("hebrew_niqqud")
                         .tokenizer("standard")
+                        .filter("asciifolding", "lowercase")))
+                .analyzer("hebrew_analyzer", an -> an
+                    .custom(ca -> ca
+                        .charFilter("hebrew_niqqud", "hebrew_matres", "hebrew_matres_yod")
+                        .tokenizer("standard")
+                        .filter("asciifolding", "lowercase")))
+                .analyzer("prefix_index_analyzer", an -> an
+                    .custom(ca -> ca
+                        .charFilter("hebrew_niqqud")
+                        .tokenizer("standard")
+                        .filter("asciifolding", "lowercase", "edge_ngram_2_15")))
+                .analyzer("prefix_search_analyzer", an -> an
+                    .custom(ca -> ca
+                        .charFilter("hebrew_niqqud")
+                        .tokenizer("standard")
+                        .filter("asciifolding", "lowercase")))
+                .analyzer("hebrew_prefix_index_analyzer", an -> an
+                    .custom(ca -> ca
+                        .charFilter("hebrew_niqqud", "hebrew_matres", "hebrew_matres_yod")
+                        .tokenizer("standard")
+                        .filter("asciifolding", "lowercase", "edge_ngram_2_15")))
+                .analyzer("hebrew_prefix_search_analyzer", an -> an
+                    .custom(ca -> ca
+                        .charFilter("hebrew_niqqud", "hebrew_matres", "hebrew_matres_yod")
+                        .tokenizer("standard")
                         .filter("asciifolding", "lowercase")))))
         .mappings(m -> {
           for (var lang : allLanguages) {
+            var isHebrew = "he".equals(lang);
             m.properties("name." + lang, k -> k
                 .text(p -> p
-                    .analyzer("universal_analyzer")
+                    .analyzer(isHebrew ? "hebrew_analyzer" : "universal_analyzer")
                     .fields("keyword", f -> f
                         .keyword(kw -> kw
-                            .normalizer("universal_normalizer")))));
+                            .normalizer(isHebrew ? "hebrew_normalizer" : "universal_normalizer")))
+                    .fields("prefix", f -> f
+                        .text(pt -> pt
+                            .analyzer(isHebrew ? "hebrew_prefix_index_analyzer" : "prefix_index_analyzer")
+                            .searchAnalyzer(isHebrew ? "hebrew_prefix_search_analyzer" : "prefix_search_analyzer")))));
             m.properties("alt_names." + lang, k -> k
                 .text(p -> p
-                    .analyzer("universal_analyzer")
+                    .analyzer(isHebrew ? "hebrew_analyzer" : "universal_analyzer")
                     .fields("keyword", f -> f
                         .keyword(kw -> kw
-                            .normalizer("universal_normalizer")))));
+                            .normalizer(isHebrew ? "hebrew_normalizer" : "universal_normalizer")))
+                    .fields("prefix", f -> f
+                        .text(pt -> pt
+                            .analyzer(isHebrew ? "hebrew_prefix_index_analyzer" : "prefix_index_analyzer")
+                            .searchAnalyzer(isHebrew ? "hebrew_prefix_search_analyzer" : "prefix_search_analyzer")))));
           }
           m.properties("location", g -> g.geoPoint(p -> p));
           m.properties("poiProminence", n -> n.float_(f -> f));

--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -70,8 +70,19 @@ public class ElasticsearchHelper {
                     .fields("keyword", f -> f
                         .keyword(kw -> kw
                             .normalizer("universal_normalizer")))));
+            m.properties("alt_names." + lang, k -> k
+                .text(p -> p
+                    .analyzer("universal_analyzer")
+                    .fields("keyword", f -> f
+                        .keyword(kw -> kw
+                            .normalizer("universal_normalizer")))));
           }
           m.properties("location", g -> g.geoPoint(p -> p));
+          m.properties("poiProminence", n -> n.float_(f -> f));
+          m.properties("population", n -> n.integer(f -> f));
+          m.properties("poiFeatureClass", n -> n.keyword(f -> f));
+          m.properties("poiAreaNormalized", n -> n.float_(f -> f.index(false)));
+          m.properties("intermittent", n -> n.boolean_(f -> f.index(false)));
           return m;
         }));
 

--- a/src/main/java/il/org/osm/israelhiking/OsmTagUtils.java
+++ b/src/main/java/il/org/osm/israelhiking/OsmTagUtils.java
@@ -1,0 +1,279 @@
+package il.org.osm.israelhiking;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+final class OsmTagUtils {
+
+  private OsmTagUtils() {
+  }
+
+  static String classifyFeatureClass(Function<String, String> tagLookup) {
+    String natural = tagLookup.apply("natural");
+    String waterway = tagLookup.apply("waterway");
+    String place = tagLookup.apply("place");
+    String historic = tagLookup.apply("historic");
+    String tourism = tagLookup.apply("tourism");
+    String leisure = tagLookup.apply("leisure");
+    String amenity = tagLookup.apply("amenity");
+    String shop = tagLookup.apply("shop");
+    String office = tagLookup.apply("office");
+    String craft = tagLookup.apply("craft");
+    String healthcare = tagLookup.apply("healthcare");
+    String manMade = tagLookup.apply("man_made");
+    String building = tagLookup.apply("building");
+
+    String fc = null;
+    if (natural != null) {
+      switch (natural) {
+        case "peak":                  fc = "peak"; break;
+        case "volcano":               fc = "peak"; break;
+        case "hill":                  fc = "hill"; break;
+        case "ridge":                 fc = "ridge"; break;
+        case "saddle": case "gap":    fc = "saddle"; break;
+        case "cliff":                 fc = "cliff"; break;
+        case "rock": case "stone":    fc = "rock"; break;
+        case "water":                 fc = "lake"; break;
+        case "spring": case "hot_spring": fc = "spring"; break;
+        case "glacier":               fc = "glacier"; break;
+        case "bay":                   fc = "bay"; break;
+        case "cape":                  fc = "cape"; break;
+        case "beach":                 fc = "beach"; break;
+        case "wood": case "forest":   fc = "forest"; break;
+        case "valley":                fc = "valley"; break;
+        case "canyon": case "gorge":  fc = "canyon"; break;
+        case "mesa": case "plateau":  fc = "plateau"; break;
+        case "arch":                  fc = "arch"; break;
+        case "cave_entrance":         fc = "cave"; break;
+        case "wetland":               fc = "wetland"; break;
+        case "arete":                 fc = "ridge"; break;
+        case "crater":                fc = "peak"; break;
+        case "mountain_range":        fc = "peak"; break;
+        default:                      fc = "natural"; break;
+      }
+      String water = tagLookup.apply("water");
+      if ("water".equals(natural) && water != null) {
+        switch (water) {
+          case "lake":      fc = "lake"; break;
+          case "reservoir": fc = "reservoir"; break;
+          case "pond":      fc = "pond"; break;
+          case "river":     fc = "river"; break;
+          case "canal":     fc = "canal"; break;
+          case "lagoon":    fc = "lagoon"; break;
+          default:          fc = "water"; break;
+        }
+      }
+    } else if (waterway != null) {
+      switch (waterway) {
+        case "waterfall":             fc = "waterfall"; break;
+        case "river":                 fc = "river"; break;
+        case "stream":                fc = "stream"; break;
+        case "canal":                 fc = "canal"; break;
+        case "rapids":                fc = "rapids"; break;
+        default:                      fc = "waterway"; break;
+      }
+    } else if (place != null) {
+      switch (place) {
+        case "city": case "town": case "village": case "hamlet":
+        case "suburb": case "neighbourhood":
+                                      fc = place; break;
+        case "island": case "islet": fc = "island"; break;
+        case "locality":             fc = "locality"; break;
+        default:                      fc = "place"; break;
+      }
+    } else if (historic != null) {
+      fc = "historic";
+    } else if (tourism != null) {
+      switch (tourism) {
+        case "viewpoint":             fc = "viewpoint"; break;
+        case "camp_site":             fc = "campsite"; break;
+        case "attraction":            fc = "attraction"; break;
+        case "hotel": case "motel": case "hostel": case "guest_house":
+        case "apartment": case "chalet": case "alpine_hut": case "wilderness_hut":
+                                      fc = "lodging"; break;
+        case "museum": case "gallery": fc = "museum"; break;
+        case "information":           fc = "tourism"; break;
+        default:                      fc = "tourism"; break;
+      }
+    } else if (leisure != null) {
+      switch (leisure) {
+        case "park": case "garden": case "nature_reserve":
+        case "playground": case "dog_park": case "common":
+                                      fc = "park"; break;
+        case "sports_centre": case "stadium": case "pitch": case "track":
+        case "fitness_centre": case "swimming_pool": case "golf_course":
+        case "ice_rink": case "horse_riding":
+                                      fc = "sports"; break;
+        default:                      fc = "leisure"; break;
+      }
+    } else if (amenity != null) {
+      switch (amenity) {
+        case "restaurant": case "cafe": case "fast_food": case "bar":
+        case "pub": case "food_court": case "biergarten": case "ice_cream":
+                                      fc = "food"; break;
+        case "place_of_worship": case "monastery":
+                                      fc = "religious"; break;
+        case "school": case "university": case "college": case "kindergarten":
+        case "library":
+                                      fc = "education"; break;
+        case "hospital": case "clinic": case "pharmacy": case "doctors":
+        case "dentist": case "veterinary":
+                                      fc = "medical"; break;
+        case "townhall": case "courthouse": case "police": case "fire_station":
+        case "post_office": case "embassy": case "prison":
+                                      fc = "government"; break;
+        case "fuel": case "charging_station":
+                                      fc = "fuel"; break;
+        case "parking": case "parking_space": case "bicycle_parking":
+        case "motorcycle_parking": case "taxi":
+                                      fc = "parking"; break;
+        case "bus_station": case "ferry_terminal":
+                                      fc = "transit"; break;
+        case "theatre": case "cinema": case "arts_centre":
+                                      fc = "museum"; break;
+        default:                      fc = "amenity"; break;
+      }
+    } else if (shop != null) {
+      fc = "shop";
+    } else if (office != null) {
+      fc = "office";
+    } else if (craft != null) {
+      fc = "office";
+    } else if (healthcare != null) {
+      fc = "medical";
+    } else if (manMade != null) {
+      switch (manMade) {
+        case "tower": case "lighthouse": case "bridge": case "obelisk":
+        case "water_tower": case "windmill": case "watermill": case "pier":
+                                      fc = "structure"; break;
+        default:                      fc = "man_made"; break;
+      }
+    } else if (building != null && !"no".equals(building) && !"none".equals(building)
+               && !"No".equals(building)) {
+      switch (building) {
+        case "church": case "chapel": case "cathedral": case "mosque":
+        case "synagogue": case "temple": case "shrine":
+                                      fc = "religious"; break;
+        case "hotel":                 fc = "lodging"; break;
+        case "hospital":              fc = "medical"; break;
+        case "school": case "university": case "college":
+                                      fc = "education"; break;
+        case "train_station":         fc = "transit"; break;
+        default:                      fc = "building"; break;
+      }
+    }
+    return fc;
+  }
+
+  private static final String[] ALT_NAME_TAG_BASES = {
+      "alt_name", "official_name", "short_name", "loc_name", "int_name"
+  };
+
+  /** old_name is deliberately excluded — a stale former name can overtake the real one. */
+  static Map<String, List<String>> buildAltNames(String[] supportedLanguages,
+      Function<String, String> tagLookup) {
+    Map<String, List<String>> altNames = null;
+    for (String language : supportedLanguages) {
+      var suffixedTags = Arrays.stream(ALT_NAME_TAG_BASES)
+          .map(base -> base + ":" + language)
+          .toArray(String[]::new);
+      var collected = collectVariants(tagLookup, suffixedTags);
+      if (collected != null) {
+        if (altNames == null) {
+          altNames = new HashMap<String, List<String>>();
+        }
+        altNames.put(language, collected);
+      }
+    }
+    var collectedDefault = collectVariants(tagLookup, ALT_NAME_TAG_BASES);
+    if (collectedDefault != null) {
+      if (altNames == null) {
+        altNames = new HashMap<String, List<String>>();
+      }
+      altNames.put("default", collectedDefault);
+    }
+    return altNames;
+  }
+
+  private static List<String> collectVariants(Function<String, String> tagLookup, String[] tags) {
+    var variants = new LinkedHashSet<String>();
+    for (String tag : tags) {
+      var raw = tagLookup.apply(tag);
+      if (raw == null || raw.isEmpty()) {
+        continue;
+      }
+      for (String part : raw.split(";")) {
+        var trimmed = part.trim();
+        if (!trimmed.isEmpty()) {
+          variants.add(trimmed);
+        }
+      }
+    }
+    return variants.isEmpty() ? null : new ArrayList<>(variants);
+  }
+
+  // Lowercase 'm' excluded: it's metres, so "1500m" parses to 1500, not mega.
+  private static final String GLUED_MAGNITUDE_SUFFIXES = "kKMB";
+  private static final double[] GLUED_MAGNITUDE_VALUES = { 1e3, 1e3, 1e6, 1e9 };
+
+  static double parseFirstNumber(String raw) {
+    if (raw == null) {
+      return Double.NaN;
+    }
+    StringBuilder sb = new StringBuilder();
+    boolean seenDigit = false;
+    boolean seenDot = false;
+    boolean seenSign = false;
+    boolean lastWasNumeric = false;
+    double multiplier = 1.0;
+    for (int i = 0; i < raw.length(); i++) {
+      char c = raw.charAt(i);
+      if (c >= '0' && c <= '9') {
+        sb.append(c);
+        seenDigit = true;
+        lastWasNumeric = true;
+      } else if (c == '-' && !seenDigit && !seenSign) {
+        sb.append(c);
+        seenSign = true;
+      } else if (c == '.' && seenDigit && !seenDot) {
+        sb.append(c);
+        seenDot = true;
+        lastWasNumeric = true;
+      } else if ((c == ',' || c == ' ' || c == '\'') && seenDigit) {
+        lastWasNumeric = false;
+      } else if (seenDigit) {
+        int magIdx = lastWasNumeric ? GLUED_MAGNITUDE_SUFFIXES.indexOf(c) : -1;
+        if (magIdx >= 0) {
+          multiplier = GLUED_MAGNITUDE_VALUES[magIdx];
+        }
+        break;
+      }
+    }
+    if (!seenDigit) {
+      return Double.NaN;
+    }
+    return Double.parseDouble(sb.toString()) * multiplier;
+  }
+
+  static Integer computePopulation(String place, String populationTag) {
+    if (place == null) {
+      return null;
+    }
+    double parsed = parseFirstNumber(populationTag);
+    if (Double.isFinite(parsed) && parsed > 0) {
+      return (int) Math.min(parsed, Integer.MAX_VALUE);
+    }
+    switch (place) {
+      case "city":    return 1_000_000;
+      case "town":    return 50_000;
+      case "village": return 2_000;
+      case "hamlet":  return 200;
+      default:        return null;
+    }
+  }
+}

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.math.NumberUtils;
@@ -30,6 +31,8 @@ import com.onthegomap.planetiler.reader.osm.OsmRelationInfo;
 import il.org.osm.israelhiking.ElasticsearchHelper.ElasticRunContext;
 
 public class PlanetSearchProfile implements Profile {
+  private static final Logger LOGGER = Logger.getLogger(PlanetSearchProfile.class.getName());
+
   private PlanetilerConfig config;
   private ElasticRunContext context;
 
@@ -95,6 +98,34 @@ public class PlanetSearchProfile implements Profile {
     pointDocument.image = feature.getString("image");
     pointDocument.wikimedia_commons = feature.getString("wikimedia_commons");
     pointDocument.website = feature.getString("website");
+    pointDocument.poiFeatureClass = OsmTagUtils.classifyFeatureClass(feature::getString);
+    pointDocument.alt_names = OsmTagUtils.buildAltNames(this.context.supportedLanguages(), feature::getString);
+    pointDocument.population = OsmTagUtils.computePopulation(
+        feature.getString("place"), feature.getString("population"));
+    setEnrichmentSignals(pointDocument, feature);
+  }
+
+  private void setEnrichmentSignals(PointDocument pointDocument, WithTags feature) {
+    if (feature instanceof SourceFeature sf && sf.canBePolygon()) {
+      try {
+        pointDocument.poiAreaNormalized = normalizeArea(sf.areaMeters());
+      } catch (Exception e) {
+        // Unbuildable polygons are common here; never fail the build over one.
+        LOGGER.fine(() -> "poiAreaNormalized skipped for " + sourceFeatureToDocumentId(sf)
+            + " (" + e.getClass().getSimpleName() + ": " + e.getMessage() + ")");
+      }
+    }
+    if (feature.hasTag("intermittent", "yes")) {
+      pointDocument.intermittent = Boolean.TRUE;
+    }
+  }
+
+  static float normalizeArea(double areaM) {
+    if (Double.isNaN(areaM) || areaM <= 0) {
+      return 0f;
+    }
+    double norm = Math.log1p(areaM) / Math.log1p(1e11);
+    return (float) Math.max(0.0, Math.min(1.0, norm));
   }
 
   private void setDifficulty(PointDocument pointDocument, WithTags feature) {

--- a/src/main/java/il/org/osm/israelhiking/PointDocument.java
+++ b/src/main/java/il/org/osm/israelhiking/PointDocument.java
@@ -1,10 +1,15 @@
 package il.org.osm.israelhiking;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 class PointDocument {
   public Map<String, String> name = new HashMap<String, String>();
+  public Map<String, List<String>> alt_names;
   public Map<String, String> description = new HashMap<String, String>();
   public String wikidata;
   public String image;
@@ -18,4 +23,11 @@ class PointDocument {
   public double poiLength = 0;
   public String website;
   public double[] location;
+
+  // null => omitted (NON_NULL) so ES uses missing:1.0 and old docs keep working.
+  public Float poiProminence;
+  public Float poiAreaNormalized;
+  public Boolean intermittent;
+  public Integer population;
+  public String poiFeatureClass;
 }

--- a/src/test/java/il/org/osm/israelhiking/AddAltNamesTest.java
+++ b/src/test/java/il/org/osm/israelhiking/AddAltNamesTest.java
@@ -1,0 +1,121 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Pins buildAltNames: per-language and default alt-name collection from the alias tag family. */
+@Tag("unit")
+public class AddAltNamesTest {
+
+    private static final String[] LANGS = { "en", "he", "ru", "ar", "es" };
+
+    private static Function<String, String> tags(Map<String, String> m) {
+        return m::get;
+    }
+
+    @Test
+    public void splitsSemicolonSeparatedMultiValues() {
+
+        var altNames = OsmTagUtils.buildAltNames(LANGS,
+                tags(Map.of("alt_name", "Foo;Bar;Baz")));
+        assertEquals(List.of("Foo", "Bar", "Baz"), altNames.get("default"),
+                "alt_name must be split on ';' and all variants kept");
+    }
+
+    @Test
+    public void trimsWhitespaceAndDropsEmptyParts() {
+        var altNames = OsmTagUtils.buildAltNames(LANGS,
+                tags(Map.of("alt_name", " Foo ;; Bar ;  ")));
+        assertEquals(List.of("Foo", "Bar"), altNames.get("default"),
+                "parts must be trimmed and empty parts dropped");
+    }
+
+    @Test
+    public void deDuplicatesWhileKeepingOrder() {
+        var map = new HashMap<String, String>();
+        map.put("alt_name", "Foo;Bar");
+        map.put("official_name", "Bar;Qux");
+        var altNames = OsmTagUtils.buildAltNames(LANGS, tags(map));
+        assertEquals(List.of("Foo", "Bar", "Qux"), altNames.get("default"),
+                "duplicate variants across tags must be collapsed, insertion order preserved");
+    }
+
+    @Test
+    public void excludesOldName() {
+
+        var altNames = OsmTagUtils.buildAltNames(LANGS,
+                tags(Map.of("old_name", "Former Name")));
+        assertNull(altNames, "old_name must be excluded entirely (no alt_names produced)");
+    }
+
+    @Test
+    public void includesOfficialShortLocAndIntName() {
+        var map = new HashMap<String, String>();
+        map.put("official_name", "Official");
+        map.put("short_name", "Sh");
+        map.put("loc_name", "Local");
+        map.put("int_name", "International");
+        var altNames = OsmTagUtils.buildAltNames(LANGS, tags(map));
+        var def = altNames.get("default");
+        assertTrue(def.contains("Official"), "official_name must be indexed");
+        assertTrue(def.contains("Sh"), "short_name must be indexed");
+        assertTrue(def.contains("Local"), "loc_name must be indexed");
+        assertTrue(def.contains("International"), "int_name must be indexed");
+    }
+
+    @Test
+    public void languageSuffixedTagsGoUnderTheirLanguageKey() {
+        var map = new HashMap<String, String>();
+        map.put("alt_name:he", "המיסדים;יונתן");
+        map.put("alt_name:en", "IBT");
+        var altNames = OsmTagUtils.buildAltNames(LANGS, tags(map));
+        assertEquals(List.of("המיסדים", "יונתן"), altNames.get("he"), "alt_name:he must key under 'he', split");
+        assertEquals(List.of("IBT"), altNames.get("en"), "alt_name:en must key under 'en'");
+        assertFalse(altNames.containsKey("default"), "no bare alt_name => no 'default' key");
+    }
+
+    @Test
+    public void theIbtCase_altNameEnIbtIsSearchable() {
+
+        var altNames = OsmTagUtils.buildAltNames(LANGS,
+                tags(Map.of("alt_name:en", "IBT")));
+        assertEquals(List.of("IBT"), altNames.get("en"));
+    }
+
+    @Test
+    public void languageAndDefaultTagsCoexist() {
+
+        var map = new HashMap<String, String>();
+        map.put("alt_name:he", "המיסדים");
+        map.put("alt_name", "Founders");
+        var altNames = OsmTagUtils.buildAltNames(LANGS, tags(map));
+        assertEquals(List.of("המיסדים"), altNames.get("he"));
+        assertEquals(List.of("Founders"), altNames.get("default"),
+                "the bare alt_name must still be added under 'default' alongside the language key");
+    }
+
+    @Test
+    public void emptyTagValueIsIgnored() {
+
+        var altNames = OsmTagUtils.buildAltNames(LANGS, tags(Map.of("alt_name", "")));
+        assertNull(altNames, "an empty alt_name value must produce no alt_names");
+    }
+
+    @Test
+    public void noVariantTagsYieldsNull() {
+
+        var altNames = OsmTagUtils.buildAltNames(LANGS,
+                tags(Map.of("name", "Just A Name", "old_name", "stale")));
+        assertNull(altNames, "a feature with no variant tags must produce no alt_names");
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/ComputePopulationTest.java
+++ b/src/test/java/il/org/osm/israelhiking/ComputePopulationTest.java
@@ -1,0 +1,89 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Pins computePopulation: parsed population, place-class fallbacks, and null for non-places. */
+@Tag("unit")
+public class ComputePopulationTest {
+
+  @Test
+  public void nullPlaceYieldsNull() {
+    assertNull(OsmTagUtils.computePopulation(null, "12345"));
+    assertNull(OsmTagUtils.computePopulation(null, null));
+  }
+
+  @Test
+  public void finitePositiveTagWins() {
+    assertEquals(12_345, OsmTagUtils.computePopulation("city", "12345"));
+
+    assertEquals(1_500_000, OsmTagUtils.computePopulation("city", "1.5M"));
+    assertEquals(50_000, OsmTagUtils.computePopulation("village", "50k"));
+  }
+
+  @Test
+  public void tagOverridesLadder() {
+
+    assertEquals(9_001, OsmTagUtils.computePopulation("village", "9001"));
+  }
+
+  @Test
+  public void hugeButFiniteRealValueClampsToMaxInt() {
+
+    assertEquals(Integer.MAX_VALUE, OsmTagUtils.computePopulation("city", "3000000000"));
+    assertEquals(Integer.MAX_VALUE, OsmTagUtils.computePopulation("city", "3B"));
+  }
+
+  @Test
+  public void infinityGarbageTagFallsThroughToLadder() {
+
+    String huge = "9".repeat(400);
+    assertEquals(50_000, OsmTagUtils.computePopulation("town", huge));
+  }
+
+  @Test
+  public void infinityGarbageTagOnNonSettlementYieldsNull() {
+    String huge = "9".repeat(400);
+    assertNull(OsmTagUtils.computePopulation("island", huge));
+  }
+
+  @Test
+  public void ladderFallbackWhenTagMissing() {
+    assertEquals(1_000_000, OsmTagUtils.computePopulation("city", null));
+    assertEquals(50_000, OsmTagUtils.computePopulation("town", null));
+    assertEquals(2_000, OsmTagUtils.computePopulation("village", null));
+    assertEquals(200, OsmTagUtils.computePopulation("hamlet", null));
+  }
+
+  @Test
+  public void ladderFallbackWhenTagNonNumeric() {
+    assertEquals(2_000, OsmTagUtils.computePopulation("village", "yes"));
+    assertEquals(200, OsmTagUtils.computePopulation("hamlet", "unknown"));
+  }
+
+  @Test
+  public void zeroAndNegativeTagFallThroughToLadder() {
+    assertEquals(2_000, OsmTagUtils.computePopulation("village", "0"));
+    assertEquals(2_000, OsmTagUtils.computePopulation("village", "-5"));
+  }
+
+  @Test
+  public void nonSettlementPlaceYieldsNull() {
+    assertNull(OsmTagUtils.computePopulation("island", null));
+    assertNull(OsmTagUtils.computePopulation("islet", null));
+    assertNull(OsmTagUtils.computePopulation("locality", null));
+    assertNull(OsmTagUtils.computePopulation("suburb", null));
+    assertNull(OsmTagUtils.computePopulation("neighbourhood", null));
+    assertNull(OsmTagUtils.computePopulation("sea", null));
+    assertNull(OsmTagUtils.computePopulation("ocean", null));
+  }
+
+  @Test
+  public void nonSettlementPlaceWithRealTagStillUsesTag() {
+
+    assertEquals(1_500, OsmTagUtils.computePopulation("locality", "1500"));
+  }
+}

--- a/src/test/java/il/org/osm/israelhiking/EnrichmentSignalsTest.java
+++ b/src/test/java/il/org/osm/israelhiking/EnrichmentSignalsTest.java
@@ -1,0 +1,177 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
+
+import com.onthegomap.planetiler.config.PlanetilerConfig;
+import com.onthegomap.planetiler.geo.GeometryException;
+import com.onthegomap.planetiler.reader.SimpleFeature;
+import com.onthegomap.planetiler.reader.SourceFeature;
+import com.onthegomap.planetiler.reader.WithTags;
+
+import il.org.osm.israelhiking.ElasticsearchHelper.ElasticRunContext;
+
+/** Pins convertTagsToDocument's enrichment wiring and setEnrichmentSignals' area, catch and intermittent branches. */
+@Tag("unit")
+public class EnrichmentSignalsTest {
+
+    private static final String[] LANGS = { "en", "he", "ru", "ar", "es" };
+    private static final GeometryFactory GF = new GeometryFactory();
+
+    private static PlanetSearchProfile profile() throws Exception {
+        var context = new ElasticRunContext(null, "points", "bbox", "points1", "bbox1", LANGS);
+        var config = PlanetilerConfig.defaults();
+        for (var ctor : PlanetSearchProfile.class.getDeclaredConstructors()) {
+            var params = ctor.getParameterTypes();
+            if (params.length == 2) {
+                return (PlanetSearchProfile) ctor.newInstance(config, context);
+            }
+            if (params.length == 3) {
+                return (PlanetSearchProfile) ctor.newInstance(config, context, emptyOf(params[2]));
+            }
+        }
+        throw new IllegalStateException("no usable PlanetSearchProfile constructor");
+    }
+
+    private static Object emptyOf(Class<?> qrankIndexType) throws Exception {
+        var empty = qrankIndexType.getDeclaredMethod("empty");
+        empty.setAccessible(true);
+        return empty.invoke(null);
+    }
+
+    private static void convert(PlanetSearchProfile p, PointDocument doc, WithTags feature) throws Exception {
+        Method m = PlanetSearchProfile.class.getDeclaredMethod(
+                "convertTagsToDocument", PointDocument.class, WithTags.class);
+        m.setAccessible(true);
+        m.invoke(p, doc, feature);
+    }
+
+    private static void enrich(PlanetSearchProfile p, PointDocument doc, WithTags feature) throws Exception {
+        Method m = PlanetSearchProfile.class.getDeclaredMethod(
+                "setEnrichmentSignals", PointDocument.class, WithTags.class);
+        m.setAccessible(true);
+        m.invoke(p, doc, feature);
+    }
+
+    private static Polygon square(double side) {
+        Coordinate[] ring = {
+            new Coordinate(0, 0), new Coordinate(0, side),
+            new Coordinate(side, side), new Coordinate(side, 0), new Coordinate(0, 0)
+        };
+        return GF.createPolygon(ring);
+    }
+
+    private static SourceFeature latLonFeature(Geometry geom, Map<String, Object> tags, long id) {
+        return SimpleFeature.create(geom, tags, "test", "test", id);
+    }
+
+    @Test
+    public void convertWritesEnrichmentSignalsForPolygonFeature() throws Exception {
+        var feature = latLonFeature(square(0.01),
+                Map.of("name", "Lake Test", "natural", "water", "water", "lake",
+                        "place", "village", "population", "2000",
+                        "alt_name", "Test Lake", "intermittent", "yes"),
+                1L);
+        var doc = new PointDocument();
+        convert(profile(), doc, feature);
+
+        assertEquals("lake", doc.poiFeatureClass);
+        assertEquals(List.of("Test Lake"), doc.alt_names.get("default"));
+        assertEquals(2000, doc.population);
+        assertTrue(doc.poiAreaNormalized != null && doc.poiAreaNormalized > 0f,
+                "a buildable polygon must get a positive normalized area");
+        assertEquals(Boolean.TRUE, doc.intermittent);
+    }
+
+    @Test
+    public void nonPolygonPointLeavesAreaAndIntermittentUnset() throws Exception {
+        var point = latLonFeature(GF.createPoint(new Coordinate(0, 0)),
+                Map.of("name", "A Node"), 2L);
+        var doc = new PointDocument();
+        enrich(profile(), doc, point);
+
+        assertNull(doc.poiAreaNormalized, "a point has no polygon area");
+        assertNull(doc.intermittent);
+    }
+
+    @Test
+    public void intermittentTagSetsTheFlagWithoutAnArea() throws Exception {
+        var point = latLonFeature(GF.createPoint(new Coordinate(0, 0)),
+                Map.of("waterway", "stream", "intermittent", "yes"), 3L);
+        var doc = new PointDocument();
+        enrich(profile(), doc, point);
+
+        assertEquals(Boolean.TRUE, doc.intermittent);
+        assertNull(doc.poiAreaNormalized);
+    }
+
+    @Test
+    public void nonSourceFeatureWithTagsSkipsAreaAndStillReadsIntermittent() throws Exception {
+        WithTags feature = WithTags.from(Map.of("intermittent", "yes"));
+        var doc = new PointDocument();
+        enrich(profile(), doc, feature);
+
+        assertNull(doc.poiAreaNormalized, "a non-SourceFeature has no geometry to area-normalize");
+        assertEquals(Boolean.TRUE, doc.intermittent);
+    }
+
+    @Test
+    public void unbuildablePolygonAreaIsSkippedNotThrown() throws Exception {
+        Logger logger = Logger.getLogger(PlanetSearchProfile.class.getName());
+        Level previous = logger.getLevel();
+        logger.setLevel(Level.FINE);
+        try {
+            var feature = new ThrowingPolygonFeature(Map.of("name", "Broken Area"), 11L);
+            var doc = new PointDocument();
+            enrich(profile(), doc, feature);
+            assertNull(doc.poiAreaNormalized, "an unbuildable polygon must leave the area unset, not throw");
+        } finally {
+            logger.setLevel(previous);
+        }
+    }
+
+    private static final class ThrowingPolygonFeature extends SourceFeature {
+        ThrowingPolygonFeature(Map<String, Object> tags, long id) {
+            super(tags, "test", "test", null, id);
+        }
+
+        @Override
+        public Geometry worldGeometry() throws GeometryException {
+            throw new GeometryException("test", "unbuildable polygon");
+        }
+
+        @Override
+        public Geometry latLonGeometry() throws GeometryException {
+            throw new GeometryException("test", "unbuildable polygon");
+        }
+
+        @Override
+        public boolean isPoint() {
+            return false;
+        }
+
+        @Override
+        public boolean canBePolygon() {
+            return true;
+        }
+
+        @Override
+        public boolean canBeLine() {
+            return false;
+        }
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/HebrewMatresRuleTest.java
+++ b/src/test/java/il/org/osm/israelhiking/HebrewMatresRuleTest.java
@@ -1,0 +1,61 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Pins the doubled-only Hebrew matres fold: collapse doubled vav/yod, leave single letters intact. */
+@Tag("unit")
+public class HebrewMatresRuleTest {
+
+    @Test
+    public void collapsesDoubledVav() {
+
+        assertEquals("דויד", ElasticsearchHelper.applyHebrewMatresDoubledOnly("דוויד"),
+                "a doubled vav (וו) must collapse to a single vav (ו)");
+    }
+
+    @Test
+    public void collapsesDoubledYod() {
+
+        assertEquals("בילי", ElasticsearchHelper.applyHebrewMatresDoubledOnly("ביילי"),
+                "a doubled yod (יי) must collapse to a single yod (י)");
+    }
+
+    @Test
+    public void collapsesDoubledAtWordStart() {
+        assertEquals("ויקי", ElasticsearchHelper.applyHebrewMatresDoubledOnly("וויקי"),
+                "doubled vav at the start must also collapse");
+    }
+
+    @Test
+    public void leavesSingleVavUntouched() {
+
+        assertEquals("אור", ElasticsearchHelper.applyHebrewMatresDoubledOnly("אור"),
+                "a single vav must be left intact (homograph-safety: אור must NOT become אר)");
+    }
+
+    @Test
+    public void leavesSingleYodUntouched() {
+        assertEquals("עיר", ElasticsearchHelper.applyHebrewMatresDoubledOnly("עיר"),
+                "a single yod must be left intact (עיר must NOT become ער)");
+    }
+
+    @Test
+    public void doesNotFixTheClientDefectiveSpelling() {
+
+        var full = "אופניים";
+        var defective = "אפניים";
+        var foldedFull = ElasticsearchHelper.applyHebrewMatresDoubledOnly(full);
+        var foldedDefective = ElasticsearchHelper.applyHebrewMatresDoubledOnly(defective);
+        org.junit.jupiter.api.Assertions.assertNotEquals(foldedFull, foldedDefective,
+                "doubled-only does NOT make full and defective spellings collide (HV01/HV02 unfixed) "
+                        + "— the missing-vav gap survives; only the deferred interior-vav rule closes it");
+    }
+
+    @Test
+    public void nullIsNull() {
+        assertEquals(null, ElasticsearchHelper.applyHebrewMatresDoubledOnly(null));
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/NormalizeAreaTest.java
+++ b/src/test/java/il/org/osm/israelhiking/NormalizeAreaTest.java
@@ -1,0 +1,34 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Pins normalizeArea's log-scaled [0,1] mapping and its degenerate-input guards. */
+@Tag("unit")
+public class NormalizeAreaTest {
+
+    @Test
+    public void zeroAndNegativeAndNaNAreZero() {
+        assertEquals(0f, PlanetSearchProfile.normalizeArea(0));
+        assertEquals(0f, PlanetSearchProfile.normalizeArea(-100));
+        assertEquals(0f, PlanetSearchProfile.normalizeArea(Double.NaN));
+    }
+
+    @Test
+    public void outputIsClampedToUnitRange() {
+
+        assertEquals(1f, PlanetSearchProfile.normalizeArea(1e15));
+        float mid = PlanetSearchProfile.normalizeArea(1_000_000);
+        assertTrue(mid > 0f && mid < 1f, "a finite area must land strictly inside (0,1)");
+    }
+
+    @Test
+    public void largerAreaScoresHigher() {
+        assertTrue(PlanetSearchProfile.normalizeArea(10_000_000)
+                > PlanetSearchProfile.normalizeArea(10_000),
+                "a bigger polygon must get a higher size proxy");
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/ParseFirstNumberTest.java
+++ b/src/test/java/il/org/osm/israelhiking/ParseFirstNumberTest.java
@@ -1,0 +1,232 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Pins parseFirstNumber's defensive free-text number parsing. */
+@Tag("unit")
+public class ParseFirstNumberTest {
+
+    private static double parse(String s) {
+        return OsmTagUtils.parseFirstNumber(s);
+    }
+
+    @Test
+    public void plainInteger() {
+        assertEquals(4302.0, parse("4302"), 1e-9);
+    }
+
+    @Test
+    public void decimal() {
+        assertEquals(4302.3, parse("4302.3"), 1e-9);
+    }
+
+    @Test
+    public void thousandsSeparatorComma() {
+        assertEquals(14115.0, parse("14,115"), 1e-9);
+    }
+
+    @Test
+    public void thousandsSeparatorSpace() {
+        assertEquals(1000.0, parse("1 000"), 1e-9);
+    }
+
+    @Test
+    public void numberWithUnitSuffix() {
+        assertEquals(14115.0, parse("14115 ft"), 1e-9);
+    }
+
+    @Test
+    public void yesIsNotANumber() {
+        assertTrue(Double.isNaN(parse("yes")));
+    }
+
+    @Test
+    public void nullIsNaN() {
+        assertTrue(Double.isNaN(parse(null)));
+    }
+
+    @Test
+    public void emptyIsNaN() {
+        assertTrue(Double.isNaN(parse("")));
+    }
+
+    @Test
+    public void rangeTakesFirstNumber() {
+
+        assertEquals(100.0, parse("100-200"), 1e-9);
+    }
+
+    @Test
+    public void secondDotEndsTheNumber() {
+
+        assertEquals(1.2, parse("1.2.3"), 1e-9);
+        assertEquals(192.168, parse("192.168.0.1"), 1e-9);
+    }
+
+    @Test
+    public void pureNonNumericIsNaN() {
+        assertTrue(Double.isNaN(parse("abc")));
+    }
+
+    @Test
+    public void commaThousandsWithUnitSuffix() {
+
+        assertEquals(1234.0, parse("1,234 m"), 1e-9);
+    }
+
+    @Test
+    public void negativeElevation() {
+
+        assertEquals(-413.0, parse("-413"), 1e-9);
+    }
+
+    @Test
+    public void negativeWithUnitSuffix() {
+        assertEquals(-413.0, parse("-413 m"), 1e-9);
+    }
+
+    @Test
+    public void loneMinusIsNaN() {
+        assertTrue(Double.isNaN(parse("-")));
+    }
+
+    @Test
+    public void minusThenNonNumericIsNaN() {
+        assertTrue(Double.isNaN(parse("-abc")));
+    }
+
+    @Test
+    public void gluedMagnitudeSuffixMultiplies() {
+
+        assertEquals(1_500_000.0, parse("1.5M"), 1e-9);
+        assertEquals(50_000.0, parse("50k"), 1e-9);
+        assertEquals(2_000_000.0, parse("2M"), 1e-9);
+        assertEquals(3_200.0, parse("3.2k"), 1e-9);
+        assertEquals(2_000_000_000.0, parse("2B"), 1e-9);
+        assertEquals(10_000.0, parse("10K"), 1e-9);
+    }
+
+    @Test
+    public void negativeWithMagnitudeSuffixMultiplies() {
+        assertEquals(-2_000_000.0, parse("-2M"), 1e-9);
+    }
+
+    @Test
+    public void multiplierEndsTheNumber_trailingCharsIgnored() {
+
+        assertEquals(50_000.0, parse("50kk"), 1e-9);
+        assertEquals(1_000_000.0, parse("1MM"), 1e-9);
+        assertEquals(1_500.0, parse("1.5km"), 1e-9);
+        assertEquals(1_500_000.0, parse("1.5M5"), 1e-9);
+        assertEquals(50_000.0, parse("50K100"), 1e-9);
+        assertEquals(1_000_000.0, parse("1.M"), 1e-9);
+    }
+
+    @Test
+    public void multiplierBeforeDigitsIsIgnored() {
+
+        assertEquals(50.0, parse("M50"), 1e-9);
+        assertEquals(50.0, parse("k50"), 1e-9);
+    }
+
+    @Test
+    public void onlyKkMbAreMultipliers_otherLettersAreTrailingUnits() {
+        assertEquals(1.5, parse("1.5G"), 1e-9);
+        assertEquals(1.0, parse("1b"), 1e-9);
+        assertEquals(1.0, parse("1g"), 1e-9);
+        assertEquals(1_000_000.0, parse("1Mb"), 1e-9);
+    }
+
+    @Test
+    public void spaceSeparatedMagnitudeLetterDoesNotMultiply() {
+
+        assertEquals(1.5, parse("1.5 M"), 1e-9);
+        assertEquals(1.5, parse("1.5 km"), 1e-9);
+        assertEquals(1.5, parse("1.5\tM"), 1e-9);
+    }
+
+    @Test
+    public void gluedMetresUnitStillParses() {
+        assertEquals(1500.0, parse("1500m"), 1e-9);
+        assertEquals(4302.0, parse("4302m"), 1e-9);
+        assertEquals(5.0, parse("5m"), 1e-9);
+        assertEquals(100.0, parse("100m2"), 1e-9);
+        assertEquals(5.0, parse("5mi"), 1e-9);
+        assertEquals(1.5, parse("1.5mm"), 1e-9);
+    }
+
+    @Test
+    public void unitSeparatedBySpaceStillParses() {
+        assertEquals(14115.0, parse("14,115 ft"), 1e-9);
+        assertEquals(1200.0, parse("1200 m"), 1e-9);
+    }
+
+    @ParameterizedTest(name = "\"{0}\" -> NaN")
+    @ValueSource(strings = {
+        " ", "  ", "--", "- ", "no", ".", "..", "-.", "k", "M", "kg",
+        "١٢٣"
+    })
+    public void variousNonNumbersAreNaN(String input) {
+        assertTrue(Double.isNaN(parse(input)), "expected NaN for \"" + input + "\"");
+    }
+
+    @Test
+    public void leadingZerosAndDotQuirks() {
+        assertEquals(0.0, parse("0"), 1e-9);
+        assertEquals(0.0, parse("00"), 1e-9);
+        assertEquals(7.0, parse("007"), 1e-9);
+        assertEquals(5.0, parse("5."), 1e-9);
+        assertEquals(5.0, parse(".5"), 1e-9);
+        assertEquals(0.0, parse("-0"), 1e-9);
+    }
+
+    @Test
+    public void separatorRunsAreSwallowed() {
+        assertEquals(1000.0, parse("1,000"), 1e-9);
+        assertEquals(1000.0, parse("1'000"), 1e-9);
+        assertEquals(1_234_567.0, parse("1,234,567"), 1e-9);
+        assertEquals(1_000_000.0, parse("1 000 000"), 1e-9);
+        assertEquals(1000.0, parse("1, 000"), 1e-9);
+        assertEquals(1000.0, parse("1,,000"), 1e-9);
+        assertEquals(5.0, parse(",5"), 1e-9);
+        assertEquals(1.0, parse("1 "), 1e-9);
+    }
+
+    @Test
+    public void rangesAndTrailingPunctuation() {
+        assertEquals(1.0, parse("1-2-3"), 1e-9);
+        assertEquals(5.0, parse("5-"), 1e-9);
+        assertEquals(100.0, parse("100 - 200"), 1e-9);
+        assertEquals(1.5, parse("1.5-2.5M"), 1e-9);
+    }
+
+    @Test
+    public void europeanDecimalCommaIsMisreadAsThousands() {
+
+        assertEquals(15_000_000.0, parse("1,5M"), 1e-9);
+        assertEquals(15_000_000.0, parse("1 5M"), 1e-9);
+    }
+
+    @Test
+    public void onlyAsciiSpaceIsASeparator_nbspEndsTheNumber() {
+
+        assertEquals(5.0, parse("5 000"), 1e-9);
+        assertEquals(5000.0, parse("5 000"), 1e-9);
+    }
+
+    @Test
+    public void neverThrowsOnAdversarialInput() {
+
+        String[] nasty = { null, "", "-", ".", "k", "M", "١٢٣", "1,,,M", "----",
+            "..M", "9".repeat(400), "-".repeat(50) + "5", "1.5 \tMkBx" };
+        for (String s : nasty) {
+            parse(s);
+        }
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/PointsAnalyzerMappingTest.java
+++ b/src/test/java/il/org/osm/israelhiking/PointsAnalyzerMappingTest.java
@@ -1,0 +1,116 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.StringWriter;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
+import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesClient;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.endpoints.BooleanResponse;
+import co.elastic.clients.util.ObjectBuilder;
+import jakarta.json.stream.JsonGenerator;
+
+/** Asserts createPointsIndex emits the prefix and Hebrew-matres analyzers and the name.prefix subfield. */
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+public class PointsAnalyzerMappingTest {
+
+    @Mock
+    private ElasticsearchClient esClient;
+
+    @Mock
+    private ElasticsearchIndicesClient indicesClient;
+
+    private final String[] supportedLanguages = { "en", "he", "ru", "ar", "es" };
+
+    @BeforeEach
+    void setUp() {
+        when(esClient.indices()).thenReturn(indicesClient);
+    }
+
+    private String createPointsIndexJson() throws Exception {
+        when(indicesClient.existsAlias(any(java.util.function.Function.class)))
+                .thenReturn(new BooleanResponse(false));
+        when(indicesClient.exists(any(java.util.function.Function.class)))
+                .thenReturn(new BooleanResponse(true));
+
+        ElasticsearchHelper.createPointsIndex(esClient, "points", supportedLanguages);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Function<CreateIndexRequest.Builder, ObjectBuilder<CreateIndexRequest>>> captor =
+                ArgumentCaptor.forClass(Function.class);
+        verify(indicesClient).create(captor.capture());
+
+        CreateIndexRequest request = captor.getValue()
+                .apply(new CreateIndexRequest.Builder())
+                .build();
+
+        JsonpMapper mapper = new JacksonJsonpMapper();
+        var sw = new StringWriter();
+        try (JsonGenerator gen = mapper.jsonProvider().createGenerator(sw)) {
+            request.serialize(gen, mapper);
+        }
+        return sw.toString();
+    }
+
+    @Test
+    public void declaresEdgeNgramPrefixSubfieldWithSplitAnalyzers() throws Exception {
+        var json = createPointsIndexJson();
+        assertTrue(json.contains("\"prefix\""), "name.<lang> must declare a .prefix subfield");
+        assertTrue(json.contains("prefix_index_analyzer"), "the .prefix index analyzer must be defined");
+        assertTrue(json.contains("prefix_search_analyzer"),
+                "the .prefix SEARCH analyzer (non-ngram) must be defined — the index/search split");
+        assertTrue(json.contains("edge_ngram_2_15"), "an edge_ngram token filter must be in the settings");
+    }
+
+    @Test
+    public void declaresHebrewMatresFiltersAndAnalyzers() throws Exception {
+        var json = createPointsIndexJson();
+        assertTrue(json.contains("hebrew_matres"), "the doubled-vav matres char_filter must be defined");
+        assertTrue(json.contains("hebrew_analyzer"), "a Hebrew-scoped analyzer must be defined");
+        assertTrue(json.contains("hebrew_normalizer"), "a Hebrew-scoped keyword normalizer must be defined");
+        assertTrue(json.contains("hebrew_prefix_index_analyzer"),
+                "the he-scoped prefix INDEX analyzer (matres + edge_ngram) must be defined");
+        assertTrue(json.contains("hebrew_prefix_search_analyzer"),
+                "the he-scoped prefix SEARCH analyzer (matres, no edge_ngram) must be defined");
+
+        assertTrue(json.contains("universal_analyzer"), "universal_analyzer must still exist");
+    }
+
+    @Test
+    public void altNamesHebrewCarriesHebrewAnalyzerAndPrefix() throws Exception {
+        var json = createPointsIndexJson();
+        JsonNode props = new ObjectMapper().readTree(json)
+                .path("mappings").path("properties");
+        JsonNode altHe = props.path("alt_names.he");
+        assertEquals("hebrew_analyzer", altHe.path("analyzer").asText(),
+                "alt_names.he must use the Hebrew analyzer, mirroring name.he");
+        assertEquals("hebrew_normalizer",
+                altHe.path("fields").path("keyword").path("normalizer").asText(),
+                "alt_names.he.keyword must use the Hebrew normalizer");
+        assertEquals("hebrew_prefix_index_analyzer",
+                altHe.path("fields").path("prefix").path("analyzer").asText(),
+                "alt_names.he must expose the he-scoped prefix subfield");
+        assertEquals("universal_analyzer", props.path("alt_names.en").path("analyzer").asText(),
+                "alt_names.en stays on the universal analyzer");
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/PointsIndexMappingTest.java
+++ b/src/test/java/il/org/osm/israelhiking/PointsIndexMappingTest.java
@@ -1,0 +1,83 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.StringWriter;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
+import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesClient;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.endpoints.BooleanResponse;
+import co.elastic.clients.util.ObjectBuilder;
+import jakarta.json.stream.JsonGenerator;
+
+/** Asserts createPointsIndex maps the computed ranking-signal fields. */
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+public class PointsIndexMappingTest {
+
+    @Mock
+    private ElasticsearchClient esClient;
+
+    @Mock
+    private ElasticsearchIndicesClient indicesClient;
+
+    private final String[] supportedLanguages = { "en", "he", "ru", "ar", "es" };
+
+    @BeforeEach
+    void setUp() {
+        when(esClient.indices()).thenReturn(indicesClient);
+    }
+
+    private String createPointsIndexJson() throws Exception {
+
+        when(indicesClient.existsAlias(any(java.util.function.Function.class)))
+                .thenReturn(new BooleanResponse(false));
+        when(indicesClient.exists(any(java.util.function.Function.class)))
+                .thenReturn(new BooleanResponse(true));
+
+        ElasticsearchHelper.createPointsIndex(esClient, "points", supportedLanguages);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Function<CreateIndexRequest.Builder, ObjectBuilder<CreateIndexRequest>>> captor =
+                ArgumentCaptor.forClass(Function.class);
+        verify(indicesClient).create(captor.capture());
+
+        CreateIndexRequest request = captor.getValue()
+                .apply(new CreateIndexRequest.Builder())
+                .build();
+
+        JsonpMapper mapper = new JacksonJsonpMapper();
+        var sw = new StringWriter();
+        try (JsonGenerator gen = mapper.jsonProvider().createGenerator(sw)) {
+            request.serialize(gen, mapper);
+        }
+        return sw.toString();
+    }
+
+    @Test
+    public void mappingDeclaresComputedRankingFields() throws Exception {
+        var json = createPointsIndexJson();
+        assertTrue(json.contains("poiProminence"), "poiProminence must be mapped");
+        assertTrue(json.contains("population"), "population must be mapped");
+        assertTrue(json.contains("poiFeatureClass"), "poiFeatureClass must be mapped");
+        assertTrue(json.contains("poiAreaNormalized"), "poiAreaNormalized must be mapped");
+        assertTrue(json.contains("intermittent"), "intermittent must be mapped");
+
+        assertTrue(json.contains("name.default"), "name.<lang> primary fields must remain");
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/SetFeatureClassTest.java
+++ b/src/test/java/il/org/osm/israelhiking/SetFeatureClassTest.java
@@ -1,0 +1,255 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Pins the OSM-tag to feature_class classifier across landform, water, place and built tags. */
+@Tag("unit")
+public class SetFeatureClassTest {
+
+    private static Function<String, String> tags(Map<String, String> m) {
+        return m::get;
+    }
+
+    private static String classify(Map<String, String> m) {
+        return OsmTagUtils.classifyFeatureClass(tags(m));
+    }
+
+    @Test
+    public void canyonAndGorgeMapToCanyon() {
+        assertEquals("canyon", classify(Map.of("natural", "canyon")));
+        assertEquals("canyon", classify(Map.of("natural", "gorge")));
+    }
+
+    @Test
+    public void mesaAndPlateauMapToPlateau() {
+        assertEquals("plateau", classify(Map.of("natural", "mesa")));
+        assertEquals("plateau", classify(Map.of("natural", "plateau")));
+    }
+
+    @Test
+    public void archCaveAndWetlandGetTheirOwnClass() {
+        assertEquals("arch", classify(Map.of("natural", "arch")));
+        assertEquals("cave", classify(Map.of("natural", "cave_entrance")));
+        assertEquals("wetland", classify(Map.of("natural", "wetland")));
+    }
+
+    @Test
+    public void areteCraterAndRangeFoldToExistingClasses() {
+        assertEquals("ridge", classify(Map.of("natural", "arete")));
+        assertEquals("peak", classify(Map.of("natural", "crater")));
+        assertEquals("peak", classify(Map.of("natural", "mountain_range")));
+    }
+
+    @Test
+    public void valleyIsUnchanged() {
+        assertEquals("valley", classify(Map.of("natural", "valley")));
+    }
+
+    @Test
+    public void peakVolcanoAndWaterRefinementUnchanged() {
+        assertEquals("peak", classify(Map.of("natural", "peak")));
+        assertEquals("peak", classify(Map.of("natural", "volcano")));
+        assertEquals("reservoir", classify(Map.of("natural", "water", "water", "reservoir")));
+        assertEquals("lake", classify(Map.of("natural", "water")));
+    }
+
+    @Test
+    public void waterRiverAndCanalAreNotMislabelledAsLake() {
+
+        assertEquals("river", classify(Map.of("natural", "water", "water", "river")));
+        assertEquals("canal", classify(Map.of("natural", "water", "water", "canal")));
+        assertEquals("lagoon", classify(Map.of("natural", "water", "water", "lagoon")));
+        assertEquals("water", classify(Map.of("natural", "water", "water", "oxbow")));
+
+        assertEquals("lake", classify(Map.of("natural", "water", "water", "lake")));
+        assertEquals("reservoir", classify(Map.of("natural", "water", "water", "reservoir")));
+        assertEquals("pond", classify(Map.of("natural", "water", "water", "pond")));
+        assertEquals("lake", classify(Map.of("natural", "water")));
+    }
+
+    @Test
+    public void unrecognisedNaturalFallsBackToNaturalCatchAll() {
+
+        assertEquals("natural", classify(Map.of("natural", "sand")));
+    }
+
+    @Test
+    public void railwayAndLanduseStayNull() {
+
+        assertNull(classify(Map.of("railway", "station")));
+        assertNull(classify(Map.of("landuse", "forest")));
+    }
+
+    @Test
+    public void lodgingTourismMapsToLodging() {
+        assertEquals("lodging", classify(Map.of("tourism", "hotel")));
+        assertEquals("lodging", classify(Map.of("tourism", "guest_house")));
+        assertEquals("museum", classify(Map.of("tourism", "museum")));
+
+        assertEquals("viewpoint", classify(Map.of("tourism", "viewpoint")));
+        assertEquals("campsite", classify(Map.of("tourism", "camp_site")));
+    }
+
+    @Test
+    public void amenityMapsToPoiClasses() {
+        assertEquals("food", classify(Map.of("amenity", "restaurant")));
+        assertEquals("food", classify(Map.of("amenity", "cafe")));
+        assertEquals("religious", classify(Map.of("amenity", "place_of_worship")));
+        assertEquals("education", classify(Map.of("amenity", "school")));
+        assertEquals("medical", classify(Map.of("amenity", "pharmacy")));
+        assertEquals("government", classify(Map.of("amenity", "townhall")));
+        assertEquals("parking", classify(Map.of("amenity", "parking")));
+        assertEquals("fuel", classify(Map.of("amenity", "fuel")));
+
+        assertEquals("amenity", classify(Map.of("amenity", "bench")));
+    }
+
+    @Test
+    public void leisureShopOfficeHealthcareMapped() {
+        assertEquals("park", classify(Map.of("leisure", "park")));
+        assertEquals("park", classify(Map.of("leisure", "nature_reserve")));
+        assertEquals("sports", classify(Map.of("leisure", "sports_centre")));
+        assertEquals("shop", classify(Map.of("shop", "supermarket")));
+        assertEquals("office", classify(Map.of("office", "lawyer")));
+        assertEquals("medical", classify(Map.of("healthcare", "clinic")));
+    }
+
+    @Test
+    public void manMadeAndBuildingMapped() {
+        assertEquals("structure", classify(Map.of("man_made", "lighthouse")));
+        assertEquals("man_made", classify(Map.of("man_made", "antenna")));
+        assertEquals("religious", classify(Map.of("building", "church")));
+        assertEquals("transit", classify(Map.of("building", "train_station")));
+
+        assertEquals("building", classify(Map.of("building", "yes")));
+        assertEquals("building", classify(Map.of("building", "hall")));
+
+        assertNull(classify(Map.of("building", "no")));
+        assertNull(classify(Map.of("building", "none")));
+    }
+
+    @Test
+    public void outdoorWinsOverBuiltTags() {
+
+        assertEquals("viewpoint", classify(Map.of("tourism", "viewpoint", "building", "yes")));
+        assertEquals("peak", classify(Map.of("natural", "peak", "amenity", "restaurant")));
+        assertEquals("lake", classify(Map.of("natural", "water", "leisure", "park")));
+    }
+
+    @Test
+    public void naturalWinsOverOtherPrimaryTags() {
+
+        assertEquals("canyon", classify(Map.of("natural", "canyon", "place", "locality")));
+    }
+
+    @Test
+    public void noTagsYieldsNull() {
+        assertNull(classify(Map.of("name", "Anonymous")));
+    }
+
+    @Test
+    public void nullTagLookupResultYieldsNull() {
+
+        assertNull(OsmTagUtils.classifyFeatureClass(t -> null));
+    }
+
+    @Test
+    public void naturalLandformArmsClassified() {
+        assertEquals("hill", classify(Map.of("natural", "hill")));
+        assertEquals("ridge", classify(Map.of("natural", "ridge")));
+        assertEquals("saddle", classify(Map.of("natural", "saddle")));
+        assertEquals("saddle", classify(Map.of("natural", "gap")));
+        assertEquals("cliff", classify(Map.of("natural", "cliff")));
+        assertEquals("rock", classify(Map.of("natural", "rock")));
+        assertEquals("rock", classify(Map.of("natural", "stone")));
+        assertEquals("glacier", classify(Map.of("natural", "glacier")));
+        assertEquals("bay", classify(Map.of("natural", "bay")));
+        assertEquals("cape", classify(Map.of("natural", "cape")));
+        assertEquals("beach", classify(Map.of("natural", "beach")));
+        assertEquals("forest", classify(Map.of("natural", "wood")));
+        assertEquals("forest", classify(Map.of("natural", "forest")));
+    }
+
+    @Test
+    public void naturalSpringArmsClassified() {
+        assertEquals("spring", classify(Map.of("natural", "spring")));
+        assertEquals("spring", classify(Map.of("natural", "hot_spring")));
+    }
+
+    @Test
+    public void waterwaySubtypesClassified() {
+        assertEquals("waterfall", classify(Map.of("waterway", "waterfall")));
+        assertEquals("river", classify(Map.of("waterway", "river")));
+        assertEquals("stream", classify(Map.of("waterway", "stream")));
+        assertEquals("canal", classify(Map.of("waterway", "canal")));
+        assertEquals("rapids", classify(Map.of("waterway", "rapids")));
+
+        assertEquals("waterway", classify(Map.of("waterway", "drain")));
+    }
+
+    @Test
+    public void placeSubtypesClassified() {
+
+        assertEquals("city", classify(Map.of("place", "city")));
+        assertEquals("hamlet", classify(Map.of("place", "hamlet")));
+        assertEquals("suburb", classify(Map.of("place", "suburb")));
+        assertEquals("neighbourhood", classify(Map.of("place", "neighbourhood")));
+        assertEquals("island", classify(Map.of("place", "island")));
+        assertEquals("island", classify(Map.of("place", "islet")));
+        assertEquals("locality", classify(Map.of("place", "locality")));
+
+        assertEquals("place", classify(Map.of("place", "county")));
+    }
+
+    @Test
+    public void historicAlwaysMapsToHistoric() {
+        assertEquals("historic", classify(Map.of("historic", "castle")));
+        assertEquals("historic", classify(Map.of("historic", "ruins")));
+    }
+
+    @Test
+    public void tourismRemainingArmsClassified() {
+        assertEquals("attraction", classify(Map.of("tourism", "attraction")));
+
+        assertEquals("tourism", classify(Map.of("tourism", "information")));
+
+        assertEquals("tourism", classify(Map.of("tourism", "zoo")));
+    }
+
+    @Test
+    public void leisureUnknownFallsBackToLeisure() {
+        assertEquals("leisure", classify(Map.of("leisure", "marina")));
+    }
+
+    @Test
+    public void amenityTransitAndArtsArmsClassified() {
+        assertEquals("transit", classify(Map.of("amenity", "bus_station")));
+        assertEquals("museum", classify(Map.of("amenity", "theatre")));
+    }
+
+    @Test
+    public void craftMapsToOffice() {
+
+        assertEquals("office", classify(Map.of("craft", "carpenter")));
+    }
+
+    @Test
+    public void buildingCapitalNoIsNotClassified() {
+
+        assertNull(classify(Map.of("building", "No")));
+    }
+
+    @Test
+    public void buildingRemainingSubtypesClassified() {
+        assertEquals("lodging", classify(Map.of("building", "hotel")));
+        assertEquals("medical", classify(Map.of("building", "hospital")));
+        assertEquals("education", classify(Map.of("building", "school")));
+    }
+}


### PR DESCRIPTION
> 🚧 **Draft until #72 merges.** This branch is stacked on #72, so the diff above currently includes #72's files too. Once #72 is merged, I'll rebase this onto `main` (its diff collapses to just the analyzer files) and mark it ready. Review **#72 first**.

---

## What

Second of three small PRs replacing #71. Adds the points-index analyzers.

- An edge-ngram `name.<lang>.prefix` subfield for as-you-type recall.
- A Hebrew **doubled-matres** fold on `name.he` (doubled vav → single vav, doubled yod → single yod; single letters are never dropped), so Hebrew searches match spelling variants (כתיב מלא / חסר) they previously missed.
- The same Hebrew analyzer + `.prefix` treatment is mirrored onto `alt_names.<lang>`.

Additive: unmapped/old documents are unaffected.

## ⚠️ One intended behavior change — Hebrew

`name.he` (and `alt_names.he`) move to a `hebrew_analyzer`. This pairs with the Site-side `query_norm`; **both halves must deploy together**. Hebrew results intentionally change for the better; the new exact-name bonus is additive ≥ 0, so this is not a regression for old clients.

## Stack — review #72 first

> **Note on the diff:** this branch is stacked on **#72** (enrichment fields). GitHub shows the cumulative diff because cross-fork PRs can't target a branch that isn't in this repo yet. **This PR's own change is only the analyzer additions:**
> - `ElasticsearchHelper.java` — analyzer/normalizer/char-filter definitions, the `name.<lang>.prefix` subfield, and the `alt_names.<lang>` Hebrew mirror
> - `HebrewMatresRuleTest.java`, `PointsAnalyzerMappingTest.java`
>
> Everything else in the diff belongs to #72. Once #72 merges, this PR's diff collapses to just the above. Merge order: #72 → this → prominence.

No code comments beyond one-line WHY notes, per review feedback on #63/#71.