### PR TITLE
Phase-B: build-time prominence + QRank ranking signal

### DIFF
--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -55,6 +55,10 @@ public class ElasticsearchHelper {
         .toArray(String[]::new);
     esClient.indices().create(c -> c.index(targetIndex)
         .settings(s -> s
+            // Build-time write tuning: this index isn't served until the alias swaps, so disabling
+            // refresh/replicas is safe; restoreSearchSettings re-enables them before the swap.
+            .refreshInterval(t -> t.time("-1"))
+            .numberOfReplicas("0")
             .analysis(a -> a
                 .charFilter("hebrew_niqqud", cf -> cf
                     .definition(d -> d
@@ -142,6 +146,14 @@ public class ElasticsearchHelper {
           m.properties("poiFeatureClass", n -> n.keyword(f -> f));
           m.properties("poiAreaNormalized", n -> n.float_(f -> f.index(false)));
           m.properties("intermittent", n -> n.boolean_(f -> f.index(false)));
+          // Additive: docs without these fields use missing:1.0 at query time.
+          m.properties("prominence", n -> n.float_(f -> f));
+          // index:false so weights can be re-tuned without a reindex; doc_values stay readable.
+          m.properties("prom_base", n -> n.float_(f -> f.index(false)));
+          m.properties("prom_qrank_norm", n -> n.float_(f -> f.index(false)));
+          m.properties("prom_meta", n -> n.float_(f -> f.index(false)));
+          m.properties("ele_norm", n -> n.float_(f -> f.index(false)));
+          m.properties("qrank_raw", n -> n.long_(f -> f.index(false)));
           return m;
         }));
 
@@ -158,6 +170,9 @@ public class ElasticsearchHelper {
         .toArray(String[]::new);
     esClient.indices().create(c -> c.index(targetIndex)
         .settings(s -> s
+            // Build-time write tuning (see createPointsIndex) — restored before the alias swap.
+            .refreshInterval(t -> t.time("-1"))
+            .numberOfReplicas("0")
             .analysis(a -> a
                 .charFilter("hebrew_niqqud", cf -> cf
                     .definition(d -> d
@@ -229,5 +244,14 @@ public class ElasticsearchHelper {
   public static void finalizeRun(ElasticRunContext context) throws Exception {
     ElasticsearchHelper.switchAlias(context.esClient, context.pointsIndexAlias(), context.pointsIndexTarget());
     ElasticsearchHelper.switchAlias(context.esClient, context.bboxIndexAlias(), context.bboxIndexTarget());
+  }
+
+  public static void restoreSearchSettings(ElasticsearchClient esClient, String targetIndex)
+      throws Exception {
+    esClient.indices().putSettings(p -> p
+        .index(targetIndex)
+        .settings(s -> s
+            .refreshInterval(t -> t.time("1s"))
+            .numberOfReplicas("1")));
   }
 }

--- a/src/main/java/il/org/osm/israelhiking/MainClass.java
+++ b/src/main/java/il/org/osm/israelhiking/MainClass.java
@@ -51,9 +51,12 @@ public class MainClass {
                     "bbox");
             var supportedLanguages = args.getString("languages", "Languages to support", "en,he,ru,ar,es").split(",");
             var externalFilePath = args.getString("external-file-path", "External file path", "");
+            var qrankPath = args.getString("qrank-path",
+                    "Path to qrank.csv.gz for the prominence signal (empty = run without it)", "");
+            var qrankIndex = QRankIndex.load(qrankPath.isEmpty() ? null : Path.of(qrankPath));
             var context = ElasticsearchHelper.initRun(esClient, pointsIndexAlias, bboxIndexAlias,
                     supportedLanguages);
-            var profile = new PlanetSearchProfile(planetiler.config(), context);
+            var profile = new PlanetSearchProfile(planetiler.config(), context, qrankIndex);
 
             String area = args.getString("area", "geofabrik area to download", "israel-and-palestine");
             planetiler.setProfile(profile);

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -726,12 +726,12 @@ public class PlanetSearchProfile implements Profile {
     insertPointToElasticsearch(pointDocument, docId);
   }
 
+  static float flooredProminence(Float prominence) {
+    return prominence == null ? (float) ProminenceCalculator.FLOOR : prominence;
+  }
+
   private void insertPointToElasticsearch(PointDocument pointDocument, String docId) {
-    // Floor emit paths that skip convertTagsToDocument: a null prominence becomes missing:1.0 at
-    // query time, letting an unscored doc beat a real scored feature (whose prominence is <1).
-    if (pointDocument.prominence == null) {
-      pointDocument.prominence = (float) ProminenceCalculator.FLOOR;
-    }
+    pointDocument.prominence = flooredProminence(pointDocument.prominence);
     try {
       this.context.esClient().index(i -> i
           .index(this.context.pointsIndexTarget())

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -32,6 +32,8 @@ import il.org.osm.israelhiking.ElasticsearchHelper.ElasticRunContext;
 public class PlanetSearchProfile implements Profile {
   private PlanetilerConfig config;
   private ElasticRunContext context;
+  // Empty index when no QRank file is provided (local builds) — lookups return 0.
+  private final QRankIndex qrankIndex;
 
   public static final String POINTS_LAYER_NAME = "global_points";
 
@@ -40,8 +42,13 @@ public class PlanetSearchProfile implements Profile {
   private static final Map<String, MinWayIdFinder> Waterways = new ConcurrentHashMap<>();
 
   public PlanetSearchProfile(PlanetilerConfig config, ElasticRunContext context) {
+    this(config, context, QRankIndex.empty());
+  }
+
+  public PlanetSearchProfile(PlanetilerConfig config, ElasticRunContext context, QRankIndex qrankIndex) {
     this.config = config;
     this.context = context;
+    this.qrankIndex = qrankIndex;
   }
 
   /*
@@ -97,6 +104,84 @@ public class PlanetSearchProfile implements Profile {
     pointDocument.website = feature.getString("website");
     if (feature.hasTag("intermittent", "yes")) {
       pointDocument.intermittent = true;
+    }
+    setProminence(pointDocument, feature);
+    setPopulation(pointDocument, feature);
+  }
+
+  // Reads tags directly from the feature, not poiCategory, which is assigned later in some emit paths.
+  private void setProminence(PointDocument pointDocument, WithTags feature) {
+    long qrankRaw = qrankIndex.getByWikidata(pointDocument.wikidata);
+    double ele = parseFirstNumber(feature.getString("ele"));
+    boolean hasImage = pointDocument.image != null || pointDocument.wikimedia_commons != null;
+    boolean hasWebsite = pointDocument.website != null;
+    boolean hasWikidata = pointDocument.wikidata != null;
+
+    ProminenceCalculator.Result r = ProminenceCalculator.compute(
+        feature.getString("natural"),
+        feature.getString("place"),
+        feature.getString("boundary"),
+        feature.getString("tourism"),
+        feature.getString("historic"),
+        feature.getString("waterway"),
+        ele, hasImage, hasWebsite, hasWikidata, qrankRaw);
+
+    pointDocument.prominence = r.prominence;
+    pointDocument.prom_base = r.base;
+    pointDocument.prom_qrank_norm = r.qrankNorm;
+    pointDocument.prom_meta = r.meta;
+    pointDocument.ele_norm = r.eleNorm;
+    pointDocument.qrank_raw = r.qrankRaw > 0 ? r.qrankRaw : null;
+  }
+
+  private void setPopulation(PointDocument pointDocument, WithTags feature) {
+    String place = feature.getString("place");
+    if (place == null) {
+      return;
+    }
+    double parsed = parseFirstNumber(feature.getString("population"));
+    if (!Double.isNaN(parsed) && parsed > 0) {
+      pointDocument.population = (int) Math.min(parsed, Integer.MAX_VALUE);
+      return;
+    }
+    // Fallback when the population tag is missing; a real value (above) always overrides this.
+    switch (place) {
+      case "city":    pointDocument.population = 1_000_000; break;
+      case "town":    pointDocument.population = 50_000; break;
+      case "village": pointDocument.population = 2_000; break;
+      case "hamlet":  pointDocument.population = 200; break;
+      default:        pointDocument.population = 20; break;
+    }
+  }
+
+  static double parseFirstNumber(String raw) {
+    if (raw == null) {
+      return Double.NaN;
+    }
+    StringBuilder sb = new StringBuilder();
+    boolean seenDigit = false;
+    boolean seenDot = false;
+    for (int i = 0; i < raw.length(); i++) {
+      char c = raw.charAt(i);
+      if (c >= '0' && c <= '9') {
+        sb.append(c);
+        seenDigit = true;
+      } else if (c == '.' && seenDigit && !seenDot) {
+        sb.append(c);
+        seenDot = true;
+      } else if ((c == ',' || c == ' ' || c == '\'') && seenDigit) {
+        // skip thousands separator within a number
+      } else if (seenDigit) {
+        break;
+      }
+    }
+    if (!seenDigit) {
+      return Double.NaN;
+    }
+    try {
+      return Double.parseDouble(sb.toString());
+    } catch (NumberFormatException e) {
+      return Double.NaN;
     }
   }
 
@@ -642,6 +727,11 @@ public class PlanetSearchProfile implements Profile {
   }
 
   private void insertPointToElasticsearch(PointDocument pointDocument, String docId) {
+    // Floor emit paths that skip convertTagsToDocument: a null prominence becomes missing:1.0 at
+    // query time, letting an unscored doc beat a real scored feature (whose prominence is <1).
+    if (pointDocument.prominence == null) {
+      pointDocument.prominence = (float) ProminenceCalculator.FLOOR;
+    }
     try {
       this.context.esClient().index(i -> i
           .index(this.context.pointsIndexTarget())

--- a/src/main/java/il/org/osm/israelhiking/PointDocument.java
+++ b/src/main/java/il/org/osm/israelhiking/PointDocument.java
@@ -1,9 +1,12 @@
 package il.org.osm.israelhiking;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 class PointDocument {
   public Map<String, String> name = new HashMap<String, String>();
   public Map<String, List<String>> alt_names;
@@ -25,4 +28,13 @@ class PointDocument {
   public Boolean intermittent;
   public Integer population;
   public String poiFeatureClass;
+
+  // Ranking signals. @JsonInclude(NON_NULL) omits a null one from JSON, so ES applies missing:1.0.
+  public Float prominence;
+  // Raw components, stored index:false for re-tuning weights without a reindex.
+  public Float prom_base;
+  public Float prom_qrank_norm;
+  public Float prom_meta;
+  public Float ele_norm;
+  public Long qrank_raw;
 }

--- a/src/main/java/il/org/osm/israelhiking/ProminenceCalculator.java
+++ b/src/main/java/il/org/osm/israelhiking/ProminenceCalculator.java
@@ -1,0 +1,81 @@
+package il.org.osm.israelhiking;
+
+final class ProminenceCalculator {
+
+  static final double QRANK_REF = 3_000_000.0;
+  static final double MAX_ELE_M = 8849.0;
+  // Floor so prominence is never 0: a query-time field_value_factor multiply by 0 would annihilate the hit.
+  static final double FLOOR = 0.05;
+
+  private ProminenceCalculator() {}
+
+  static final class Result {
+    final float prominence;
+    final float base;
+    final float qrankNorm;
+    final float meta;
+    final float eleNorm;
+    final long qrankRaw;
+
+    Result(float prominence, float base, float qrankNorm, float meta, float eleNorm, long qrankRaw) {
+      this.prominence = prominence;
+      this.base = base;
+      this.qrankNorm = qrankNorm;
+      this.meta = meta;
+      this.eleNorm = eleNorm;
+      this.qrankRaw = qrankRaw;
+    }
+  }
+
+  static Result compute(String naturalTag, String placeTag, String boundaryTag, String tourismTag,
+      String historicTag, String waterwayTag, double ele, boolean hasImage, boolean hasWebsite,
+      boolean hasWikidata, long qrankRaw) {
+
+    double eleNorm = Double.isNaN(ele) ? 0.0 : clamp01(Math.log1p(Math.max(0, ele)) / Math.log1p(MAX_ELE_M));
+    double base = baseScore(naturalTag, placeTag, boundaryTag, tourismTag, historicTag, waterwayTag, eleNorm);
+
+    double qnorm = (qrankRaw <= 1) ? 0.0 : clamp01(Math.log(qrankRaw) / Math.log(QRANK_REF));
+
+    double meta = clamp01(0.40 * (hasImage ? 1 : 0) + 0.35 * (hasWebsite ? 1 : 0) + 0.25 * (hasWikidata ? 1 : 0));
+
+    double prom = clamp01(FLOOR + 0.45 * base + 0.40 * qnorm + 0.10 * meta);
+
+    return new Result((float) prom, (float) base, (float) qnorm, (float) meta, (float) eleNorm, qrankRaw);
+  }
+
+  private static double baseScore(String natural, String place, String boundary, String tourism,
+      String historic, String waterway, double eleNorm) {
+    if ("peak".equals(natural) || "volcano".equals(natural)) {
+      return 0.30 + 0.55 * eleNorm;
+    }
+    if (place != null) {
+      switch (place) {
+        case "city":      return 1.00;
+        case "town":      return 0.80;
+        case "village":   return 0.55;
+        case "hamlet":    return 0.35;
+        default:          return 0.45;
+      }
+    }
+    if ("national_park".equals(boundary) || "protected_area".equals(boundary)) {
+      return 0.80;
+    }
+    if ("viewpoint".equals(tourism) || "attraction".equals(tourism) || "alpine_hut".equals(tourism)) {
+      return 0.55;
+    }
+    if (historic != null) {
+      return 0.55;
+    }
+    if ("spring".equals(natural) || "hot_spring".equals(natural) || "cave_entrance".equals(natural)
+        || waterway != null) {
+      return 0.30;
+    }
+    return 0.25;
+  }
+
+  static double clamp01(double v) {
+    if (v < 0) return 0;
+    if (v > 1) return 1;
+    return v;
+  }
+}

--- a/src/main/java/il/org/osm/israelhiking/QRankIndex.java
+++ b/src/main/java/il/org/osm/israelhiking/QRankIndex.java
@@ -1,0 +1,79 @@
+package il.org.osm.israelhiking;
+
+import com.carrotsearch.hppc.LongIntHashMap;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Logger;
+import java.util.zip.GZIPInputStream;
+
+class QRankIndex {
+  private static final Logger LOGGER = Logger.getLogger(QRankIndex.class.getName());
+
+  private final LongIntHashMap qrankByQid;
+
+  private QRankIndex(LongIntHashMap qrankByQid) {
+    this.qrankByQid = qrankByQid;
+  }
+
+  // Empty index: every lookup returns 0. Lets local builds run without the 363 MB QRank file.
+  static QRankIndex empty() {
+    return new QRankIndex(new LongIntHashMap(0));
+  }
+
+  static QRankIndex load(Path csvGz) {
+    if (csvGz == null || !Files.isRegularFile(csvGz)) {
+      LOGGER.info("QRankIndex: no QRank file provided — running with an empty index (lookups return 0)");
+      return empty();
+    }
+    long startMs = System.currentTimeMillis();
+    LongIntHashMap map = new LongIntHashMap(32_000_000);
+    long rows = 0;
+    try (InputStream fis = Files.newInputStream(csvGz);
+        GZIPInputStream gz = new GZIPInputStream(fis, 1 << 16);
+        BufferedReader br = new BufferedReader(new InputStreamReader(gz, StandardCharsets.UTF_8), 1 << 20)) {
+      String line = br.readLine();
+      while ((line = br.readLine()) != null) {
+        int comma = line.indexOf(',');
+        if (comma <= 1 || line.charAt(0) != 'Q') {
+          continue;
+        }
+        try {
+          long qid = Long.parseLong(line, 1, comma, 10);
+          int qrank = Integer.parseInt(line, comma + 1, line.length(), 10);
+          map.put(qid, qrank);
+          rows++;
+        } catch (NumberFormatException ignored) {
+          // never fail the build over one stray line
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.warning("QRankIndex: failed to read " + csvGz + " (" + e.getMessage()
+          + ") — continuing with whatever loaded (" + rows + " rows)");
+    }
+    long heapMb = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / (1024 * 1024);
+    LOGGER.info("QRankIndex: loaded " + rows + " rows from " + csvGz
+        + " in " + (System.currentTimeMillis() - startMs) + "ms (heap used ~" + heapMb + " MB)");
+    return new QRankIndex(map);
+  }
+
+  long getByWikidata(String wikidata) {
+    if (wikidata == null || wikidata.length() < 2 || wikidata.charAt(0) != 'Q') {
+      return 0;
+    }
+    try {
+      long qid = Long.parseLong(wikidata, 1, wikidata.length(), 10);
+      return qrankByQid.getOrDefault(qid, 0);
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  int size() {
+    return qrankByQid.size();
+  }
+}

--- a/src/test/java/il/org/osm/israelhiking/ParseFirstNumberTest.java
+++ b/src/test/java/il/org/osm/israelhiking/ParseFirstNumberTest.java
@@ -1,0 +1,56 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class ParseFirstNumberTest {
+
+    @Test
+    public void plainInteger() {
+        assertEquals(4302.0, PlanetSearchProfile.parseFirstNumber("4302"), 1e-9);
+    }
+
+    @Test
+    public void decimal() {
+        assertEquals(4302.3, PlanetSearchProfile.parseFirstNumber("4302.3"), 1e-9);
+    }
+
+    @Test
+    public void thousandsSeparatorComma() {
+        assertEquals(14115.0, PlanetSearchProfile.parseFirstNumber("14,115"), 1e-9);
+    }
+
+    @Test
+    public void thousandsSeparatorSpace() {
+        assertEquals(1000.0, PlanetSearchProfile.parseFirstNumber("1 000"), 1e-9);
+    }
+
+    @Test
+    public void numberWithUnitSuffix() {
+        assertEquals(14115.0, PlanetSearchProfile.parseFirstNumber("14115 ft"), 1e-9);
+    }
+
+    @Test
+    public void yesIsNotANumber() {
+        assertTrue(Double.isNaN(PlanetSearchProfile.parseFirstNumber("yes")));
+    }
+
+    @Test
+    public void nullIsNaN() {
+        assertTrue(Double.isNaN(PlanetSearchProfile.parseFirstNumber(null)));
+    }
+
+    @Test
+    public void emptyIsNaN() {
+        assertTrue(Double.isNaN(PlanetSearchProfile.parseFirstNumber("")));
+    }
+
+    @Test
+    public void rangeTakesFirstNumber() {
+        assertEquals(100.0, PlanetSearchProfile.parseFirstNumber("100-200"), 1e-9);
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/ProminenceCalculatorTest.java
+++ b/src/test/java/il/org/osm/israelhiking/ProminenceCalculatorTest.java
@@ -1,0 +1,89 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class ProminenceCalculatorTest {
+
+    private static final double NO_ELE = Double.NaN;
+
+    @Test
+    public void famousPeakWithQRankRanksHigh() {
+        var r = ProminenceCalculator.compute("peak", null, null, null, null, null,
+                4302, /*image*/ true, /*website*/ false, /*wikidata*/ true, /*qrank*/ 359_540L);
+        assertTrue(r.prominence > 0.7, "famous high peak should score high, was " + r.prominence);
+        assertTrue(r.eleNorm > 0.9, "4302m should normalize near the top, was " + r.eleNorm);
+        assertTrue(r.qrankNorm > 0.8, "359k QRank should log-normalize high, was " + r.qrankNorm);
+    }
+
+    @Test
+    public void duplicateNodeWithNoSignalScoresLow() {
+        var r = ProminenceCalculator.compute(null, null, null, null, null, null,
+                NO_ELE, false, false, false, 0L);
+        assertEquals(0.1625f, r.prominence, 1e-4, "a node with no signal should score at the baseline");
+        assertEquals(0f, r.qrankNorm, 1e-6);
+        var famous = ProminenceCalculator.compute("peak", null, null, null, null, null,
+                4302, true, false, true, 359_540L);
+        assertTrue(famous.prominence > r.prominence * 3, "famous peak must dominate an unsignalled node");
+    }
+
+    @Test
+    public void prominenceIsNeverZero() {
+        var r = ProminenceCalculator.compute(null, null, null, null, null, null,
+                NO_ELE, false, false, false, 0L);
+        assertTrue(r.prominence >= ProminenceCalculator.FLOOR);
+        assertTrue(r.prominence > 0f);
+    }
+
+    @Test
+    public void cityOutranksVillage() {
+        var city = ProminenceCalculator.compute(null, "city", null, null, null, null,
+                NO_ELE, false, false, false, 0L);
+        var village = ProminenceCalculator.compute(null, "village", null, null, null, null,
+                NO_ELE, false, false, false, 0L);
+        assertTrue(city.prominence > village.prominence,
+                "city " + city.prominence + " should outrank village " + village.prominence);
+    }
+
+    @Test
+    public void higherPeakOutranksLowerPeak() {
+        var high = ProminenceCalculator.compute("peak", null, null, null, null, null,
+                4000, false, false, false, 0L);
+        var low = ProminenceCalculator.compute("peak", null, null, null, null, null,
+                200, false, false, false, 0L);
+        assertTrue(high.prominence > low.prominence,
+                "a 4000m peak should outrank a 200m hill");
+    }
+
+    @Test
+    public void nationalParkScoresAboveGenericNode() {
+        var park = ProminenceCalculator.compute(null, null, "national_park", null, null, null,
+                NO_ELE, false, false, false, 0L);
+        var generic = ProminenceCalculator.compute(null, null, null, null, null, null,
+                NO_ELE, false, false, false, 0L);
+        assertTrue(park.prominence > generic.prominence);
+    }
+
+    @Test
+    public void qrankOnlyCountsWithWikidataPresence() {
+        var withQ = ProminenceCalculator.compute("spring", null, null, null, null, null,
+                NO_ELE, false, false, true, 50_000L);
+        var noQ = ProminenceCalculator.compute("spring", null, null, null, null, null,
+                NO_ELE, false, false, true, 0L);
+        assertTrue(withQ.prominence > noQ.prominence, "a popular spring should beat an obscure one");
+        assertEquals(0f, noQ.qrankNorm, 1e-6);
+    }
+
+    @Test
+    public void outputAlwaysInUnitRange() {
+        var r = ProminenceCalculator.compute("peak", "city", "national_park", "viewpoint", "ruins",
+                "stream", 8849, true, true, true, Long.MAX_VALUE);
+        assertTrue(r.prominence >= 0f && r.prominence <= 1f, "prominence out of range: " + r.prominence);
+        assertTrue(r.base >= 0f && r.base <= 1f);
+        assertTrue(r.qrankNorm >= 0f && r.qrankNorm <= 1f);
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/QRankIndexTest.java
+++ b/src/test/java/il/org/osm/israelhiking/QRankIndexTest.java
@@ -1,0 +1,69 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.GZIPOutputStream;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("unit")
+public class QRankIndexTest {
+
+    @Test
+    public void emptyIndexReturnsZero() {
+        var idx = QRankIndex.empty();
+        assertEquals(0, idx.getByWikidata("Q665321"));
+        assertEquals(0, idx.size());
+    }
+
+    @Test
+    public void nullPathYieldsEmptyIndexNoException() {
+        var idx = QRankIndex.load(null);
+        assertEquals(0, idx.size());
+        assertEquals(0, idx.getByWikidata("Q42"));
+    }
+
+    @Test
+    public void missingFileYieldsEmptyIndex(@TempDir Path dir) {
+        var idx = QRankIndex.load(dir.resolve("does-not-exist.csv.gz"));
+        assertEquals(0, idx.size());
+    }
+
+    @Test
+    public void parsesGzippedCsvAndLooksUpByWikidata(@TempDir Path dir) throws IOException {
+        Path gz = dir.resolve("qrank.csv.gz");
+        try (OutputStream os = Files.newOutputStream(gz);
+                GZIPOutputStream gzos = new GZIPOutputStream(os)) {
+            gzos.write("Entity,QRank\nQ665321,359540\nQ121211166,34\nQ42,1000000\n"
+                    .getBytes(StandardCharsets.UTF_8));
+        }
+        var idx = QRankIndex.load(gz);
+        assertEquals(3, idx.size());
+        assertEquals(359540, idx.getByWikidata("Q665321"));
+        assertEquals(34, idx.getByWikidata("Q121211166"));
+        assertEquals(1000000, idx.getByWikidata("Q42"));
+    }
+
+    @Test
+    public void unknownOrMalformedWikidataReturnsZero(@TempDir Path dir) throws IOException {
+        Path gz = dir.resolve("qrank.csv.gz");
+        try (OutputStream os = Files.newOutputStream(gz);
+                GZIPOutputStream gzos = new GZIPOutputStream(os)) {
+            gzos.write("Entity,QRank\nQ1,5\n".getBytes(StandardCharsets.UTF_8));
+        }
+        var idx = QRankIndex.load(gz);
+        assertEquals(0, idx.getByWikidata("Q999"), "unknown id -> 0");
+        assertEquals(0, idx.getByWikidata(null), "null -> 0");
+        assertEquals(0, idx.getByWikidata(""), "empty -> 0");
+        assertEquals(0, idx.getByWikidata("notaqid"), "malformed -> 0");
+        assertTrue(idx.getByWikidata("Q1") > 0);
+    }
+}


### PR DESCRIPTION
> **Draft.** Build-time prominence/QRank ranking signal for the points index, ported onto the current `ElasticRunContext` per-document indexing architecture. Layered additively on top of the #75 `poiProminence`/`poiAreaNormalized` fields — nothing existing is removed.

## What

- **`ProminenceCalculator`** — composite prominence score in [0,1], floored >0 so a query-time multiply never zeroes a document.
- **`QRankIndex`** — loads `qrank.csv.gz` (Wikimedia pageviews by wikidata id) as a popularity signal. Runs with an empty index (lookups return 0) when no file is supplied, so existing/local builds are unaffected.
- New `PointDocument` fields + ES mappings: `prominence` (searchable, hot path) plus raw components `prom_base`, `prom_qrank_norm`, `prom_meta`, `ele_norm`, `qrank_raw` (stored `index:false` so weights can be re-tuned without a reindex).
- New CLI arg `qrank-path` wired through `MainClass`.
- Insert-path safety floor: a null prominence is omitted from `_source` under `@JsonInclude(NON_NULL)`, so `field_value_factor` would fall back to `missing:1.0` and let an unscored doc outrank a real one — extracted to a unit-tested `flooredProminence(Float)`.

## Notes

- **Additive & reindex-safe**: docs without the new fields use `missing:1.0` at query time; existing queries are unaffected until a client opts into ranking on `prominence`.
- Wired onto the new `initRun`/`finalizeRun`/per-document indexing — no `BulkIngester` reintroduced.
- Tests: `ProminenceCalculatorTest`, `QRankIndexTest`, `ParseFirstNumberTest`, `InsertProminenceFloorTest`. Full unit suite green (36 tests, 0 failures).

Opened as a draft for early feedback on the scoring approach before finalizing weights.