### PR TITLE
Index-time prominence + QRank ranking signals (poiProminence) + population

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Additional arguments to this wrapper besides the Planetiler's arguments:
 | `es-bbox-index-alias` | The alias of the index to insert bounding boxes into, it will create "1" and "2" suffix for the relevant index before switching | `bbox` |
 | `external-file-path` | External geojson file path to allow adding non OSM features to the search and POIs. these features should have a specific format | "empty" |
 | `skip-tiles` | Collapse the tile pyramid to z0 so the `.pmtiles` archive is a near-instant stub, to speed up an Elasticsearch-only reindex. The search index is built identically; only the map tiles degrade, so do not use it for a build whose map tiles are consumed. | `false` |
+| `qrank-path` | Path to a gzipped `qrank.csv.gz` used to compute the `poiProminence` ranking signal. Optional — leave empty to build without it (every point still gets a floored prominence). | "empty" |
+
+The QRank data file comes from [https://qrank.toolforge.org](https://qrank.toolforge.org) (CC0): a gzipped CSV (`Entity,QRank`) ranking Wikidata entities by aggregated Wikimedia pageviews. `qrank-path` is optional and fully omittable — omit it and the build runs unchanged without the ~363 MB file.
 
 To run using docker (While having a local elasticsearch running at 9200):
 

--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -15,6 +15,8 @@ import co.elastic.clients.transport.rest_client.RestClientTransport;
 
 public class ElasticsearchHelper {
 
+  private static final Logger LOGGER = Logger.getLogger(ElasticsearchHelper.class.getName());
+
   // Doubled-only: folding a single vav/yod would merge real homographs. "\\u"
   // reaches ES as the literal Lucene escape.
   static final String HEBREW_VAV = "ו";
@@ -55,11 +57,6 @@ public class ElasticsearchHelper {
         .toArray(String[]::new);
     esClient.indices().create(c -> c.index(targetIndex)
         .settings(s -> s
-            // Build-time write tuning: the index being built lives under the
-            // "1"/"2" suffix and isn't served until the alias swaps, so nobody
-            // searches it during the build. Disabling periodic refresh and
-            // replicas removes the biggest per-document overhead in bulk
-            // indexing. They are restored right before the alias swap.
             .refreshInterval(t -> t.time("-1"))
             .numberOfReplicas("0")
             .analysis(a -> a
@@ -165,8 +162,6 @@ public class ElasticsearchHelper {
         .toArray(String[]::new);
     esClient.indices().create(c -> c.index(targetIndex)
         .settings(s -> s
-            // Build-time write tuning (see createPointsIndex) — restored before
-            // the alias swap.
             .refreshInterval(t -> t.time("-1"))
             .numberOfReplicas("0")
             .analysis(a -> a
@@ -237,12 +232,6 @@ public class ElasticsearchHelper {
         supportedLanguages);
   }
 
-  /**
-   * Restore normal search-time settings on a freshly-built index before it goes
-   * live: re-enable periodic refresh (createPointsIndex/createBBoxIndex disable
-   * it for faster bulk writes) and add one replica for redundancy. Call this
-   * after the final flush and a one-off refresh, just before switchAlias.
-   */
   public static void restoreSearchSettings(ElasticsearchClient esClient, String targetIndex)
       throws Exception {
     esClient.indices().putSettings(p -> p
@@ -253,18 +242,22 @@ public class ElasticsearchHelper {
   }
 
   public static void finalizeRun(ElasticRunContext context, PlanetSearchProfile profile) throws Exception {
-    // Drain every buffered document and wait for the in-flight bulk requests to
-    // finish BEFORE the alias swap, so the new index is fully populated when it
-    // goes live. Then refresh so the docs are searchable.
     profile.flush();
     context.esClient().indices().refresh(r -> r.index(context.pointsIndexTarget(), context.bboxIndexTarget()));
 
-    // Restore normal refresh/replica settings (disabled during the build to speed
-    // up bulk indexing) before the indexes go live.
     restoreSearchSettings(context.esClient(), context.pointsIndexTarget());
     restoreSearchSettings(context.esClient(), context.bboxIndexTarget());
 
-    ElasticsearchHelper.switchAlias(context.esClient(), context.pointsIndexAlias(), context.pointsIndexTarget());
     ElasticsearchHelper.switchAlias(context.esClient(), context.bboxIndexAlias(), context.bboxIndexTarget());
+
+    // A partial points index must never go live; leave the alias on the previous complete index.
+    if (profile.hasIndexingFailures()) {
+      LOGGER.warning(() -> "Leaving points alias '" + context.pointsIndexAlias()
+          + "' on the previous index: this build dropped " + profile.getFailedPointsCount()
+          + " points document(s), so '" + context.pointsIndexTarget()
+          + "' is incomplete and must not go live.");
+      return;
+    }
+    ElasticsearchHelper.switchAlias(context.esClient(), context.pointsIndexAlias(), context.pointsIndexTarget());
   }
 }

--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -31,7 +31,8 @@ public class ElasticsearchHelper {
       String bboxIndexAlias,
       String pointsIndexTarget,
       String bboxIndexTarget,
-      String[] supportedLanguages) {
+      String[] supportedLanguages,
+      QRankIndex qrankIndex) {
   }
 
   /**
@@ -224,12 +225,13 @@ public class ElasticsearchHelper {
   public static ElasticRunContext initRun(ElasticsearchClient esClient,
       String pointsIndexAlias,
       String bboxIndexAlias,
-      String[] supportedLanguages) throws Exception {
+      String[] supportedLanguages,
+      QRankIndex qrankIndex) throws Exception {
     var targetPointsIndex = ElasticsearchHelper.createPointsIndex(esClient, pointsIndexAlias,
         supportedLanguages);
     var targetBBoxIndex = ElasticsearchHelper.createBBoxIndex(esClient, bboxIndexAlias, supportedLanguages);
     return new ElasticRunContext(esClient, pointsIndexAlias, bboxIndexAlias, targetPointsIndex, targetBBoxIndex,
-        supportedLanguages);
+        supportedLanguages, qrankIndex);
   }
 
   public static void restoreSearchSettings(ElasticsearchClient esClient, String targetIndex)

--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -143,6 +143,12 @@ public class ElasticsearchHelper {
           }
           m.properties("location", g -> g.geoPoint(p -> p));
           m.properties("poiProminence", n -> n.float_(f -> f));
+          // Raw prominence components: kept for re-tuning, not searched.
+          m.properties("poiPromBase", n -> n.float_(f -> f.index(false)));
+          m.properties("poiPromQrankNorm", n -> n.float_(f -> f.index(false)));
+          m.properties("poiPromMeta", n -> n.float_(f -> f.index(false)));
+          m.properties("poiEleNorm", n -> n.float_(f -> f.index(false)));
+          m.properties("poiQrankRaw", n -> n.long_(f -> f.index(false)));
           m.properties("population", n -> n.integer(f -> f));
           m.properties("poiFeatureClass", n -> n.keyword(f -> f));
           m.properties("poiAreaNormalized", n -> n.float_(f -> f.index(false)));

--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -55,6 +55,13 @@ public class ElasticsearchHelper {
         .toArray(String[]::new);
     esClient.indices().create(c -> c.index(targetIndex)
         .settings(s -> s
+            // Build-time write tuning: the index being built lives under the
+            // "1"/"2" suffix and isn't served until the alias swaps, so nobody
+            // searches it during the build. Disabling periodic refresh and
+            // replicas removes the biggest per-document overhead in bulk
+            // indexing. They are restored right before the alias swap.
+            .refreshInterval(t -> t.time("-1"))
+            .numberOfReplicas("0")
             .analysis(a -> a
                 .charFilter("hebrew_niqqud", cf -> cf
                     .definition(d -> d
@@ -158,6 +165,10 @@ public class ElasticsearchHelper {
         .toArray(String[]::new);
     esClient.indices().create(c -> c.index(targetIndex)
         .settings(s -> s
+            // Build-time write tuning (see createPointsIndex) — restored before
+            // the alias swap.
+            .refreshInterval(t -> t.time("-1"))
+            .numberOfReplicas("0")
             .analysis(a -> a
                 .charFilter("hebrew_niqqud", cf -> cf
                     .definition(d -> d
@@ -226,8 +237,34 @@ public class ElasticsearchHelper {
         supportedLanguages);
   }
 
-  public static void finalizeRun(ElasticRunContext context) throws Exception {
-    ElasticsearchHelper.switchAlias(context.esClient, context.pointsIndexAlias(), context.pointsIndexTarget());
-    ElasticsearchHelper.switchAlias(context.esClient, context.bboxIndexAlias(), context.bboxIndexTarget());
+  /**
+   * Restore normal search-time settings on a freshly-built index before it goes
+   * live: re-enable periodic refresh (createPointsIndex/createBBoxIndex disable
+   * it for faster bulk writes) and add one replica for redundancy. Call this
+   * after the final flush and a one-off refresh, just before switchAlias.
+   */
+  public static void restoreSearchSettings(ElasticsearchClient esClient, String targetIndex)
+      throws Exception {
+    esClient.indices().putSettings(p -> p
+        .index(targetIndex)
+        .settings(s -> s
+            .refreshInterval(t -> t.time("1s"))
+            .numberOfReplicas("1")));
+  }
+
+  public static void finalizeRun(ElasticRunContext context, PlanetSearchProfile profile) throws Exception {
+    // Drain every buffered document and wait for the in-flight bulk requests to
+    // finish BEFORE the alias swap, so the new index is fully populated when it
+    // goes live. Then refresh so the docs are searchable.
+    profile.flush();
+    context.esClient().indices().refresh(r -> r.index(context.pointsIndexTarget(), context.bboxIndexTarget()));
+
+    // Restore normal refresh/replica settings (disabled during the build to speed
+    // up bulk indexing) before the indexes go live.
+    restoreSearchSettings(context.esClient(), context.pointsIndexTarget());
+    restoreSearchSettings(context.esClient(), context.bboxIndexTarget());
+
+    ElasticsearchHelper.switchAlias(context.esClient(), context.pointsIndexAlias(), context.pointsIndexTarget());
+    ElasticsearchHelper.switchAlias(context.esClient(), context.bboxIndexAlias(), context.bboxIndexTarget());
   }
 }

--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -143,7 +143,6 @@ public class ElasticsearchHelper {
           }
           m.properties("location", g -> g.geoPoint(p -> p));
           m.properties("poiProminence", n -> n.float_(f -> f));
-          // Raw prominence components: kept for re-tuning, not searched.
           m.properties("poiPromBase", n -> n.float_(f -> f.index(false)));
           m.properties("poiPromQrankNorm", n -> n.float_(f -> f.index(false)));
           m.properties("poiPromMeta", n -> n.float_(f -> f.index(false)));

--- a/src/main/java/il/org/osm/israelhiking/MainClass.java
+++ b/src/main/java/il/org/osm/israelhiking/MainClass.java
@@ -68,7 +68,31 @@ public class MainClass {
             planetiler.overwriteOutput(Path.of("data", "target", PlanetSearchProfile.POINTS_LAYER_NAME + ".pmtiles"));
             planetiler.run();
 
-            ElasticsearchHelper.finalizeRun(context);
+            // Drain buffered inserts, refresh, restore search settings, and swap
+            // the alias. This blocks on the BulkIngester so the failure counters
+            // are final by the time the gate below reads them.
+            ElasticsearchHelper.finalizeRun(context, profile);
+
+            // bbox geo_shape rejects (a few degenerate OSM relation geometries ES
+            // can't parse) are tolerated — they don't affect name search — but we
+            // surface them so they're never silent.
+            if (profile.getFailedBboxCount() > 0) {
+                LOGGER.warning("Indexing dropped " + profile.getFailedBboxCount()
+                        + " bbox document(s) (geo_shape rejects); tolerated — name search unaffected.");
+            }
+
+            // Fail the process if any POINTS document was dropped during indexing.
+            // The BulkIngester listener already counts and logs failures; without a
+            // non-zero exit here CI would mistake a partial points index for success
+            // and silently ship missing search results. Exit non-zero so the build
+            // fails loudly instead.
+            if (profile.hasIndexingFailures()) {
+                throw new IllegalStateException("Indexing finished with " + profile.getFailedPointsCount()
+                        + " failed POINTS document(s) out of " + profile.getEmittedCount()
+                        + " emitted (" + profile.getIndexedCount() + " indexed, "
+                        + profile.getFailedBboxCount() + " bbox dropped). "
+                        + "Refusing to treat a partial points index as success.");
+            }
         } finally {
             esClient.close();
         }

--- a/src/main/java/il/org/osm/israelhiking/MainClass.java
+++ b/src/main/java/il/org/osm/israelhiking/MainClass.java
@@ -51,8 +51,11 @@ public class MainClass {
                     "bbox");
             var supportedLanguages = args.getString("languages", "Languages to support", "en,he,ru,ar,es").split(",");
             var externalFilePath = args.getString("external-file-path", "External file path", "");
+            var qrankPath = args.getString("qrank-path",
+                    "Path to qrank.csv.gz for the prominence signal (empty = run without it)", "");
+            var qrankIndex = QRankIndex.load(qrankPath.isEmpty() ? null : Path.of(qrankPath));
             var context = ElasticsearchHelper.initRun(esClient, pointsIndexAlias, bboxIndexAlias,
-                    supportedLanguages);
+                    supportedLanguages, qrankIndex);
             var profile = new PlanetSearchProfile(planetiler.config(), context);
 
             String area = args.getString("area", "geofabrik area to download", "israel-and-palestine");

--- a/src/main/java/il/org/osm/israelhiking/MainClass.java
+++ b/src/main/java/il/org/osm/israelhiking/MainClass.java
@@ -68,24 +68,13 @@ public class MainClass {
             planetiler.overwriteOutput(Path.of("data", "target", PlanetSearchProfile.POINTS_LAYER_NAME + ".pmtiles"));
             planetiler.run();
 
-            // Drain buffered inserts, refresh, restore search settings, and swap
-            // the alias. This blocks on the BulkIngester so the failure counters
-            // are final by the time the gate below reads them.
             ElasticsearchHelper.finalizeRun(context, profile);
 
-            // bbox geo_shape rejects (a few degenerate OSM relation geometries ES
-            // can't parse) are tolerated — they don't affect name search — but we
-            // surface them so they're never silent.
             if (profile.getFailedBboxCount() > 0) {
                 LOGGER.warning("Indexing dropped " + profile.getFailedBboxCount()
                         + " bbox document(s) (geo_shape rejects); tolerated — name search unaffected.");
             }
 
-            // Fail the process if any POINTS document was dropped during indexing.
-            // The BulkIngester listener already counts and logs failures; without a
-            // non-zero exit here CI would mistake a partial points index for success
-            // and silently ship missing search results. Exit non-zero so the build
-            // fails loudly instead.
             if (profile.hasIndexingFailures()) {
                 throw new IllegalStateException("Indexing finished with " + profile.getFailedPointsCount()
                         + " failed POINTS document(s) out of " + profile.getEmittedCount()

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -187,6 +187,29 @@ public class PlanetSearchProfile implements Profile {
       pointDocument.intermittent = true;
     }
     setProminence(pointDocument, feature);
+    setPopulation(pointDocument, feature);
+  }
+
+  /** Population is a place/admin-layer signal only — set it for settlements, leave POIs null. */
+  private void setPopulation(PointDocument pointDocument, WithTags feature) {
+    String place = feature.getString("place");
+    if (place == null) {
+      return;
+    }
+    double parsed = parseFirstNumber(feature.getString("population"));
+    if (!Double.isNaN(parsed) && parsed > 0) {
+      pointDocument.population = (int) Math.min(parsed, Integer.MAX_VALUE);
+      return;
+    }
+    // Ladder fallback when the population tag is missing (covers the ~80% of villages/hamlets
+    // that have no number). A real value always overrides this.
+    switch (place) {
+      case "city":    pointDocument.population = 1_000_000; break;
+      case "town":    pointDocument.population = 50_000; break;
+      case "village": pointDocument.population = 2_000; break;
+      case "hamlet":  pointDocument.population = 200; break;
+      default:        pointDocument.population = 20; break;
+    }
   }
 
   /**

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.math.NumberUtils;
@@ -27,11 +29,35 @@ import com.onthegomap.planetiler.reader.WithTags;
 import com.onthegomap.planetiler.reader.osm.OsmElement;
 import com.onthegomap.planetiler.reader.osm.OsmRelationInfo;
 
+import co.elastic.clients.elasticsearch._helpers.bulk.BulkIngester;
+import co.elastic.clients.elasticsearch._helpers.bulk.BulkListener;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+
 import il.org.osm.israelhiking.ElasticsearchHelper.ElasticRunContext;
 
 public class PlanetSearchProfile implements Profile {
+  private static final Logger LOGGER = Logger.getLogger(PlanetSearchProfile.class.getName());
+
   private PlanetilerConfig config;
   private ElasticRunContext context;
+
+  // Bulk indexer: thread-safe, buffers operations and flushes them in batches.
+  // Planetiler emits features from multiple worker threads, so BulkIngester
+  // (which handles concurrent add() internally) is the right tool rather than
+  // manually batching BulkRequests with our own locking.
+  private final BulkIngester<Void> bulkIngester;
+  // Emitted/attempted docs: incremented once per bulkIngester.add(...). Lets us
+  // assert the lossless invariant emitted == indexed + failed after flush() so a
+  // doc that was emitted but never made it into any bulk batch is detectable.
+  private final LongAdder emittedCount = new LongAdder();
+  // Counters so indexing is observable instead of failing silently. Failures are
+  // split by destination index so we can fail the build on the ones that cause
+  // missing SEARCH results (points) while only warning on bbox geo_shape rejects
+  // (a few degenerate OSM relation geometries ES can't parse; they don't affect
+  // name search).
+  private final LongAdder indexedCount = new LongAdder();
+  private final LongAdder failedPointsCount = new LongAdder();
+  private final LongAdder failedBboxCount = new LongAdder();
 
   public static final String POINTS_LAYER_NAME = "global_points";
 
@@ -42,6 +68,98 @@ public class PlanetSearchProfile implements Profile {
   public PlanetSearchProfile(PlanetilerConfig config, ElasticRunContext context) {
     this.config = config;
     this.context = context;
+    this.bulkIngester = BulkIngester.of(b -> b
+        .client(context.esClient())
+        // Flush whenever any of these thresholds is hit.
+        .maxOperations(5_000)
+        .maxSize(5 * 1024 * 1024)
+        .maxConcurrentRequests(4)
+        // Listener gives us per-batch visibility instead of swallowing errors.
+        // Extracted into a named class (AccountingBulkListener) so the counting
+        // logic is directly unit-testable.
+        .listener(new AccountingBulkListener(
+            indexedCount, failedPointsCount, failedBboxCount, context.pointsIndexTarget())));
+  }
+
+  /**
+   * BulkListener that surfaces and counts every bulk outcome instead of
+   * swallowing errors. Extracted into a static class so the per-item
+   * classification (indexed vs failed) and the whole-batch failure path are
+   * unit-testable by driving {@code afterBulk} directly.
+   */
+  static final class AccountingBulkListener implements BulkListener<Void> {
+    private final LongAdder indexedCount;
+    private final LongAdder failedPointsCount;
+    private final LongAdder failedBboxCount;
+    private final String pointsIndexName;
+
+    AccountingBulkListener(LongAdder indexedCount, LongAdder failedPointsCount, LongAdder failedBboxCount,
+        String pointsIndexName) {
+      this.indexedCount = indexedCount;
+      this.failedPointsCount = failedPointsCount;
+      this.failedBboxCount = failedBboxCount;
+      this.pointsIndexName = pointsIndexName;
+    }
+
+    // A failed item destined for the points index means a missing SEARCH result
+    // (build-breaking); a failed bbox item is a geometry reject (warn-only).
+    private void recordFailure(String index) {
+      if (pointsIndexName != null && pointsIndexName.equals(index)) {
+        failedPointsCount.increment();
+      } else {
+        failedBboxCount.increment();
+      }
+    }
+
+    @Override
+    public void beforeBulk(long executionId, co.elastic.clients.elasticsearch.core.BulkRequest request,
+        List<Void> contexts) {
+      // no-op
+    }
+
+    @Override
+    public void afterBulk(long executionId, co.elastic.clients.elasticsearch.core.BulkRequest request,
+        List<Void> contexts, co.elastic.clients.elasticsearch.core.BulkResponse response) {
+      if (response.errors()) {
+        response.items().forEach(item -> {
+          if (item.error() != null) {
+            recordFailure(item.index());
+            LOGGER.warning(() -> "Failed to index id=" + item.id() + " into " + item.index()
+                + ": " + item.error().reason());
+          } else {
+            indexedCount.increment();
+          }
+        });
+      } else {
+        indexedCount.add(response.items().size());
+      }
+    }
+
+    @Override
+    public void afterBulk(long executionId, co.elastic.clients.elasticsearch.core.BulkRequest request,
+        List<Void> contexts, Throwable failure) {
+      // A whole-batch failure has no per-item index breakdown; classify each
+      // operation by the index it targeted so points failures still break the build.
+      request.operations().forEach(op -> recordFailure(bulkOperationIndex(op)));
+      LOGGER.severe(() -> "Bulk request " + executionId + " failed entirely: " + failure.getMessage());
+    }
+
+    // Best-effort extraction of the destination index from a bulk operation
+    // (index/create/update/delete variants). Null when it can't be determined,
+    // which recordFailure treats as non-points (bbox) — the conservative choice
+    // for the warn-only bucket.
+    private static String bulkOperationIndex(co.elastic.clients.elasticsearch.core.bulk.BulkOperation op) {
+      if (op.isIndex()) {
+        return op.index().index();
+      } else if (op.isCreate()) {
+        return op.create().index();
+      } else if (op.isUpdate()) {
+        return op.update().index();
+      } else if (op.isDelete()) {
+        return op.delete().index();
+      }
+      return null;
+    }
   }
 
   /*
@@ -642,14 +760,12 @@ public class PlanetSearchProfile implements Profile {
   }
 
   private void insertPointToElasticsearch(PointDocument pointDocument, String docId) {
-    try {
-      this.context.esClient().index(i -> i
-          .index(this.context.pointsIndexTarget())
-          .id(docId)
-          .document(pointDocument));
-    } catch (Exception e) {
-      // swallow
-    }
+    emittedCount.increment();
+    bulkIngester.add(BulkOperation.of(op -> op
+        .index(idx -> idx
+            .index(this.context.pointsIndexTarget())
+            .id(docId)
+            .document(pointDocument))));
   }
 
   private void insertBboxToElasticsearch(SourceFeature feature, String[] supportedLanguages) {
@@ -671,13 +787,56 @@ public class PlanetSearchProfile implements Profile {
       if (feature.hasTag("name")) {
         CoalesceIntoMap(bbox.name, "default", feature.getString("name"));
       }
-      this.context.esClient().index(i -> i
-          .index(this.context.bboxIndexTarget())
-          .id(sourceFeatureToDocumentId(feature))
-          .document(bbox));
+      String bboxDocId = sourceFeatureToDocumentId(feature);
+      emittedCount.increment();
+      bulkIngester.add(BulkOperation.of(op -> op
+          .index(idx -> idx
+              .index(this.context.bboxIndexTarget())
+              .id(bboxDocId)
+              .document(bbox))));
     } catch (Exception e) {
-      // swallow
+      // Only geometry/serialization building can throw here now; the actual
+      // indexing is handled (and its errors counted) by the bulk listener.
+      LOGGER.warning(() -> "Failed to build bbox document for "
+          + sourceFeatureToDocumentId(feature) + ": " + e.getMessage());
     }
+  }
+
+  public long getEmittedCount() {
+    return emittedCount.sum();
+  }
+
+  public long getIndexedCount() {
+    return indexedCount.sum();
+  }
+
+  /** Total failed documents across all indices (points + bbox). Keeps the
+   *  lossless invariant emitted == indexed + failed. */
+  public long getFailedCount() {
+    return failedPointsCount.sum() + failedBboxCount.sum();
+  }
+
+  /** Failed documents destined for the points index — these are missing SEARCH
+   *  results and must break the build. */
+  public long getFailedPointsCount() {
+    return failedPointsCount.sum();
+  }
+
+  /** Failed bbox documents (geo_shape rejects on degenerate OSM geometries) —
+   *  warn-only; they don't affect name search. */
+  public long getFailedBboxCount() {
+    return failedBboxCount.sum();
+  }
+
+  /**
+   * True when this run dropped at least one POINTS document: a partial points
+   * index causes missing search results, which CI must treat as a failure rather
+   * than mistake for success. bbox geo_shape rejects are warned-but-tolerated and
+   * deliberately do NOT trip this. Kept as a small pure predicate so the
+   * fail-the-build decision is unit-testable without calling {@code System.exit}.
+   */
+  public boolean hasIndexingFailures() {
+    return failedPointsCount.sum() > 0;
   }
 
   /**

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -186,6 +186,71 @@ public class PlanetSearchProfile implements Profile {
     if (feature.hasTag("intermittent", "yes")) {
       pointDocument.intermittent = true;
     }
+    setProminence(pointDocument, feature);
+  }
+
+  /**
+   * Compute the composite prominence score from OSM tags + QRank and store it (plus raw components,
+   * for re-tuning without a reindex) on the document. Reads tags directly from the feature rather
+   * than poiCategory, because poiCategory is assigned later in some emit paths.
+   */
+  private void setProminence(PointDocument pointDocument, WithTags feature) {
+    long qrankRaw = this.context.qrankIndex().getByWikidata(pointDocument.wikidata);
+    double ele = parseFirstNumber(feature.getString("ele"));
+    boolean hasImage = pointDocument.image != null || pointDocument.wikimedia_commons != null;
+    boolean hasWebsite = pointDocument.website != null;
+    boolean hasWikidata = pointDocument.wikidata != null;
+
+    ProminenceCalculator.Result r = ProminenceCalculator.compute(
+        feature.getString("natural"),
+        feature.getString("place"),
+        feature.getString("boundary"),
+        feature.getString("tourism"),
+        feature.getString("historic"),
+        feature.getString("waterway"),
+        ele, hasImage, hasWebsite, hasWikidata, qrankRaw);
+
+    pointDocument.poiProminence = r.prominence;
+    pointDocument.poiPromBase = r.base;
+    pointDocument.poiPromQrankNorm = r.qrankNorm;
+    pointDocument.poiPromMeta = r.meta;
+    pointDocument.poiEleNorm = r.eleNorm;
+    pointDocument.poiQrankRaw = r.qrankRaw > 0 ? r.qrankRaw : null;
+  }
+
+  /**
+   * Parse the first number out of a free-text OSM value like "4302", "14,115 ft", "1 000", "yes".
+   * Returns Double.NaN when there is no usable number. Never throws.
+   */
+  static double parseFirstNumber(String raw) {
+    if (raw == null) {
+      return Double.NaN;
+    }
+    StringBuilder sb = new StringBuilder();
+    boolean seenDigit = false;
+    boolean seenDot = false;
+    for (int i = 0; i < raw.length(); i++) {
+      char c = raw.charAt(i);
+      if (c >= '0' && c <= '9') {
+        sb.append(c);
+        seenDigit = true;
+      } else if (c == '.' && seenDigit && !seenDot) {
+        sb.append(c);
+        seenDot = true;
+      } else if ((c == ',' || c == ' ' || c == '\'') && seenDigit) {
+        // thousands separator within a number — skip it
+      } else if (seenDigit) {
+        break; // number ended (e.g. " ft", "-")
+      }
+    }
+    if (!seenDigit) {
+      return Double.NaN;
+    }
+    try {
+      return Double.parseDouble(sb.toString());
+    } catch (NumberFormatException e) {
+      return Double.NaN;
+    }
   }
 
   private void setDifficulty(PointDocument pointDocument, WithTags feature) {
@@ -729,7 +794,20 @@ public class PlanetSearchProfile implements Profile {
     insertPointToElasticsearch(pointDocument, docId);
   }
 
+  /**
+   * Safety floor for the insert path: every emitted document must carry a prominence so the
+   * query-time multiply is consistent. Some emit paths (ski-lift ways, relation-completion) don't
+   * run convertTagsToDocument, which would leave poiProminence null -> field_value_factor
+   * missing:1.0 -> they'd unfairly beat a real, scored feature (whose prominence is &lt;1). Floor a
+   * null to the minimum prominence; leave any real value UNCHANGED. Package-private static so it is
+   * unit-testable without the real BulkIngester.
+   */
+  static float flooredProminence(Float prominence) {
+    return prominence == null ? (float) ProminenceCalculator.FLOOR : prominence;
+  }
+
   private void insertPointToElasticsearch(PointDocument pointDocument, String docId) {
+    pointDocument.poiProminence = flooredProminence(pointDocument.poiProminence);
     try {
       bulkIngester.add(BulkOperation.of(op -> op
           .index(idx -> idx

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -802,6 +802,28 @@ public class PlanetSearchProfile implements Profile {
     }
   }
 
+  /**
+   * Flush every buffered document to Elasticsearch and wait for the in-flight
+   * bulk requests to complete. Must be called after planetiler.run() finishes
+   * emitting features and BEFORE the alias swap / refresh, so the new index is
+   * fully populated when it goes live.
+   *
+   * close() already flushes and waits internally, but we flush explicitly first
+   * (and log the remaining buffer) so the end-of-indexation flush is visible and
+   * intentional rather than an implicit side effect of close().
+   */
+  public void flush() {
+    LOGGER.info(() -> "Flushing final batch: " + bulkIngester.pendingOperations()
+        + " buffered operations, " + bulkIngester.pendingRequests() + " in-flight requests.");
+    bulkIngester.flush();
+    // close() blocks until the flushed buffer and all in-flight requests (and
+    // their listener callbacks, which update the counters) have completed.
+    bulkIngester.close();
+    LOGGER.info(() -> "Elasticsearch indexing finished: " + indexedCount.sum()
+        + " documents indexed, " + getFailedCount() + " failed ("
+        + failedPointsCount.sum() + " points, " + failedBboxCount.sum() + " bbox).");
+  }
+
   public long getEmittedCount() {
     return emittedCount.sum();
   }

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -190,7 +190,6 @@ public class PlanetSearchProfile implements Profile {
     setPopulation(pointDocument, feature);
   }
 
-  /** Population is a place/admin-layer signal only — set it for settlements, leave POIs null. */
   private void setPopulation(PointDocument pointDocument, WithTags feature) {
     String place = feature.getString("place");
     if (place == null) {
@@ -201,8 +200,6 @@ public class PlanetSearchProfile implements Profile {
       pointDocument.population = (int) Math.min(parsed, Integer.MAX_VALUE);
       return;
     }
-    // Ladder fallback when the population tag is missing (covers the ~80% of villages/hamlets
-    // that have no number). A real value always overrides this.
     switch (place) {
       case "city":    pointDocument.population = 1_000_000; break;
       case "town":    pointDocument.population = 50_000; break;
@@ -212,11 +209,6 @@ public class PlanetSearchProfile implements Profile {
     }
   }
 
-  /**
-   * Compute the composite prominence score from OSM tags + QRank and store it (plus raw components,
-   * for re-tuning without a reindex) on the document. Reads tags directly from the feature rather
-   * than poiCategory, because poiCategory is assigned later in some emit paths.
-   */
   private void setProminence(PointDocument pointDocument, WithTags feature) {
     long qrankRaw = this.context.qrankIndex().getByWikidata(pointDocument.wikidata);
     double ele = parseFirstNumber(feature.getString("ele"));
@@ -241,10 +233,6 @@ public class PlanetSearchProfile implements Profile {
     pointDocument.poiQrankRaw = r.qrankRaw > 0 ? r.qrankRaw : null;
   }
 
-  /**
-   * Parse the first number out of a free-text OSM value like "4302", "14,115 ft", "1 000", "yes".
-   * Returns Double.NaN when there is no usable number. Never throws.
-   */
   static double parseFirstNumber(String raw) {
     if (raw == null) {
       return Double.NaN;
@@ -252,25 +240,31 @@ public class PlanetSearchProfile implements Profile {
     StringBuilder sb = new StringBuilder();
     boolean seenDigit = false;
     boolean seenDot = false;
+    boolean negative = false;
     for (int i = 0; i < raw.length(); i++) {
       char c = raw.charAt(i);
       if (c >= '0' && c <= '9') {
         sb.append(c);
         seenDigit = true;
+      } else if (c == '-' && !seenDigit && i + 1 < raw.length()
+          && raw.charAt(i + 1) >= '0' && raw.charAt(i + 1) <= '9') {
+        negative = true;
       } else if (c == '.' && seenDigit && !seenDot) {
         sb.append(c);
         seenDot = true;
       } else if ((c == ',' || c == ' ' || c == '\'') && seenDigit) {
-        // thousands separator within a number — skip it
       } else if (seenDigit) {
-        break; // number ended (e.g. " ft", "-")
+        break;
+      } else {
+        negative = false;
       }
     }
     if (!seenDigit) {
       return Double.NaN;
     }
     try {
-      return Double.parseDouble(sb.toString());
+      double value = Double.parseDouble(sb.toString());
+      return negative ? -value : value;
     } catch (NumberFormatException e) {
       return Double.NaN;
     }
@@ -817,14 +811,8 @@ public class PlanetSearchProfile implements Profile {
     insertPointToElasticsearch(pointDocument, docId);
   }
 
-  /**
-   * Safety floor for the insert path: every emitted document must carry a prominence so the
-   * query-time multiply is consistent. Some emit paths (ski-lift ways, relation-completion) don't
-   * run convertTagsToDocument, which would leave poiProminence null -> field_value_factor
-   * missing:1.0 -> they'd unfairly beat a real, scored feature (whose prominence is &lt;1). Floor a
-   * null to the minimum prominence; leave any real value UNCHANGED. Package-private static so it is
-   * unit-testable without the real BulkIngester.
-   */
+  // A null poiProminence is omitted by @JsonInclude(NON_NULL), which makes field_value_factor fall
+  // back to missing:1.0 and unfairly outrank real scored features; floor nulls so that can't happen.
   static float flooredProminence(Float prominence) {
     return prominence == null ? (float) ProminenceCalculator.FLOOR : prominence;
   }

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -41,20 +41,8 @@ public class PlanetSearchProfile implements Profile {
   private PlanetilerConfig config;
   private ElasticRunContext context;
 
-  // Bulk indexer: thread-safe, buffers operations and flushes them in batches.
-  // Planetiler emits features from multiple worker threads, so BulkIngester
-  // (which handles concurrent add() internally) is the right tool rather than
-  // manually batching BulkRequests with our own locking.
   private final BulkIngester<Void> bulkIngester;
-  // Emitted/attempted docs: incremented once per bulkIngester.add(...). Lets us
-  // assert the lossless invariant emitted == indexed + failed after flush() so a
-  // doc that was emitted but never made it into any bulk batch is detectable.
   private final LongAdder emittedCount = new LongAdder();
-  // Counters so indexing is observable instead of failing silently. Failures are
-  // split by destination index so we can fail the build on the ones that cause
-  // missing SEARCH results (points) while only warning on bbox geo_shape rejects
-  // (a few degenerate OSM relation geometries ES can't parse; they don't affect
-  // name search).
   private final LongAdder indexedCount = new LongAdder();
   private final LongAdder failedPointsCount = new LongAdder();
   private final LongAdder failedBboxCount = new LongAdder();
@@ -70,51 +58,39 @@ public class PlanetSearchProfile implements Profile {
     this.context = context;
     this.bulkIngester = BulkIngester.of(b -> b
         .client(context.esClient())
-        // Flush whenever any of these thresholds is hit.
         .maxOperations(5_000)
         .maxSize(5 * 1024 * 1024)
         .maxConcurrentRequests(4)
-        // Listener gives us per-batch visibility instead of swallowing errors.
-        // Extracted into a named class (AccountingBulkListener) so the counting
-        // logic is directly unit-testable.
         .listener(new AccountingBulkListener(
-            indexedCount, failedPointsCount, failedBboxCount, context.pointsIndexTarget())));
+            indexedCount, failedPointsCount, failedBboxCount, context.bboxIndexTarget())));
   }
 
-  /**
-   * BulkListener that surfaces and counts every bulk outcome instead of
-   * swallowing errors. Extracted into a static class so the per-item
-   * classification (indexed vs failed) and the whole-batch failure path are
-   * unit-testable by driving {@code afterBulk} directly.
-   */
   static final class AccountingBulkListener implements BulkListener<Void> {
     private final LongAdder indexedCount;
     private final LongAdder failedPointsCount;
     private final LongAdder failedBboxCount;
-    private final String pointsIndexName;
+    private final String bboxIndexName;
 
     AccountingBulkListener(LongAdder indexedCount, LongAdder failedPointsCount, LongAdder failedBboxCount,
-        String pointsIndexName) {
+        String bboxIndexName) {
       this.indexedCount = indexedCount;
       this.failedPointsCount = failedPointsCount;
       this.failedBboxCount = failedBboxCount;
-      this.pointsIndexName = pointsIndexName;
+      this.bboxIndexName = bboxIndexName;
     }
 
-    // A failed item destined for the points index means a missing SEARCH result
-    // (build-breaking); a failed bbox item is a geometry reject (warn-only).
+    // Fail-closed: an undeterminable destination is bucketed as points so a points loss can't be downgraded to a tolerated bbox warning.
     private void recordFailure(String index) {
-      if (pointsIndexName != null && pointsIndexName.equals(index)) {
-        failedPointsCount.increment();
-      } else {
+      if (bboxIndexName != null && bboxIndexName.equals(index)) {
         failedBboxCount.increment();
+      } else {
+        failedPointsCount.increment();
       }
     }
 
     @Override
     public void beforeBulk(long executionId, co.elastic.clients.elasticsearch.core.BulkRequest request,
         List<Void> contexts) {
-      // no-op
     }
 
     @Override
@@ -138,16 +114,10 @@ public class PlanetSearchProfile implements Profile {
     @Override
     public void afterBulk(long executionId, co.elastic.clients.elasticsearch.core.BulkRequest request,
         List<Void> contexts, Throwable failure) {
-      // A whole-batch failure has no per-item index breakdown; classify each
-      // operation by the index it targeted so points failures still break the build.
       request.operations().forEach(op -> recordFailure(bulkOperationIndex(op)));
       LOGGER.severe(() -> "Bulk request " + executionId + " failed entirely: " + failure.getMessage());
     }
 
-    // Best-effort extraction of the destination index from a bulk operation
-    // (index/create/update/delete variants). Null when it can't be determined,
-    // which recordFailure treats as non-points (bbox) — the conservative choice
-    // for the warn-only bucket.
     private static String bulkOperationIndex(co.elastic.clients.elasticsearch.core.bulk.BulkOperation op) {
       if (op.isIndex()) {
         return op.index().index();
@@ -760,12 +730,17 @@ public class PlanetSearchProfile implements Profile {
   }
 
   private void insertPointToElasticsearch(PointDocument pointDocument, String docId) {
-    emittedCount.increment();
-    bulkIngester.add(BulkOperation.of(op -> op
-        .index(idx -> idx
-            .index(this.context.pointsIndexTarget())
-            .id(docId)
-            .document(pointDocument))));
+    try {
+      bulkIngester.add(BulkOperation.of(op -> op
+          .index(idx -> idx
+              .index(this.context.pointsIndexTarget())
+              .id(docId)
+              .document(pointDocument))));
+      emittedCount.increment();
+    } catch (RuntimeException e) {
+      failedPointsCount.increment();
+      LOGGER.warning(() -> "Failed to enqueue points doc " + docId + ": " + e.getMessage());
+    }
   }
 
   private void insertBboxToElasticsearch(SourceFeature feature, String[] supportedLanguages) {
@@ -788,36 +763,32 @@ public class PlanetSearchProfile implements Profile {
         CoalesceIntoMap(bbox.name, "default", feature.getString("name"));
       }
       String bboxDocId = sourceFeatureToDocumentId(feature);
-      emittedCount.increment();
-      bulkIngester.add(BulkOperation.of(op -> op
-          .index(idx -> idx
-              .index(this.context.bboxIndexTarget())
-              .id(bboxDocId)
-              .document(bbox))));
+      addBboxToBulk(bbox, bboxDocId);
     } catch (Exception e) {
-      // Only geometry/serialization building can throw here now; the actual
-      // indexing is handled (and its errors counted) by the bulk listener.
+      failedBboxCount.increment();
       LOGGER.warning(() -> "Failed to build bbox document for "
           + sourceFeatureToDocumentId(feature) + ": " + e.getMessage());
     }
   }
 
-  /**
-   * Flush every buffered document to Elasticsearch and wait for the in-flight
-   * bulk requests to complete. Must be called after planetiler.run() finishes
-   * emitting features and BEFORE the alias swap / refresh, so the new index is
-   * fully populated when it goes live.
-   *
-   * close() already flushes and waits internally, but we flush explicitly first
-   * (and log the remaining buffer) so the end-of-indexation flush is visible and
-   * intentional rather than an implicit side effect of close().
-   */
+  private void addBboxToBulk(BBoxDocument bbox, String bboxDocId) {
+    try {
+      bulkIngester.add(BulkOperation.of(op -> op
+          .index(idx -> idx
+              .index(this.context.bboxIndexTarget())
+              .id(bboxDocId)
+              .document(bbox))));
+      emittedCount.increment();
+    } catch (RuntimeException e) {
+      failedBboxCount.increment();
+      LOGGER.warning(() -> "Failed to enqueue bbox doc " + bboxDocId + ": " + e.getMessage());
+    }
+  }
+
   public void flush() {
     LOGGER.info(() -> "Flushing final batch: " + bulkIngester.pendingOperations()
         + " buffered operations, " + bulkIngester.pendingRequests() + " in-flight requests.");
     bulkIngester.flush();
-    // close() blocks until the flushed buffer and all in-flight requests (and
-    // their listener callbacks, which update the counters) have completed.
     bulkIngester.close();
     LOGGER.info(() -> "Elasticsearch indexing finished: " + indexedCount.sum()
         + " documents indexed, " + getFailedCount() + " failed ("
@@ -832,31 +803,18 @@ public class PlanetSearchProfile implements Profile {
     return indexedCount.sum();
   }
 
-  /** Total failed documents across all indices (points + bbox). Keeps the
-   *  lossless invariant emitted == indexed + failed. */
   public long getFailedCount() {
     return failedPointsCount.sum() + failedBboxCount.sum();
   }
 
-  /** Failed documents destined for the points index — these are missing SEARCH
-   *  results and must break the build. */
   public long getFailedPointsCount() {
     return failedPointsCount.sum();
   }
 
-  /** Failed bbox documents (geo_shape rejects on degenerate OSM geometries) —
-   *  warn-only; they don't affect name search. */
   public long getFailedBboxCount() {
     return failedBboxCount.sum();
   }
 
-  /**
-   * True when this run dropped at least one POINTS document: a partial points
-   * index causes missing search results, which CI must treat as a failure rather
-   * than mistake for success. bbox geo_shape rejects are warned-but-tolerated and
-   * deliberately do NOT trip this. Kept as a small pure predicate so the
-   * fail-the-build decision is unit-testable without calling {@code System.exit}.
-   */
   public boolean hasIndexingFailures() {
     return failedPointsCount.sum() > 0;
   }

--- a/src/main/java/il/org/osm/israelhiking/PointDocument.java
+++ b/src/main/java/il/org/osm/israelhiking/PointDocument.java
@@ -24,7 +24,6 @@ class PointDocument {
   public String website;
   public double[] location;
   public Float poiProminence;
-  // Raw prominence components, stored index:false so the weights can be re-tuned without a reindex.
   public Float poiPromBase;
   public Float poiPromQrankNorm;
   public Float poiPromMeta;

--- a/src/main/java/il/org/osm/israelhiking/PointDocument.java
+++ b/src/main/java/il/org/osm/israelhiking/PointDocument.java
@@ -1,9 +1,12 @@
 package il.org.osm.israelhiking;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 class PointDocument {
   public Map<String, String> name = new HashMap<String, String>();
   public Map<String, List<String>> alt_names;
@@ -21,6 +24,12 @@ class PointDocument {
   public String website;
   public double[] location;
   public Float poiProminence;
+  // Raw prominence components, stored index:false so the weights can be re-tuned without a reindex.
+  public Float poiPromBase;
+  public Float poiPromQrankNorm;
+  public Float poiPromMeta;
+  public Float poiEleNorm;
+  public Long poiQrankRaw;
   public Float poiAreaNormalized;
   public Boolean intermittent;
   public Integer population;

--- a/src/main/java/il/org/osm/israelhiking/ProminenceCalculator.java
+++ b/src/main/java/il/org/osm/israelhiking/ProminenceCalculator.java
@@ -1,37 +1,13 @@
 package il.org.osm.israelhiking;
 
-/**
- * Computes a composite {@code poiProminence} score in [0,1] for a feature, used at query time as a
- * {@code field_value_factor} multiplier so a major peak / well-known place outranks an obscure node
- * with the same name.
- *
- * <p>Formula (research-derived):
- * <pre>
- *   poiProminence = clamp01( 0.05 + 0.45*base + 0.40*qnorm + 0.10*meta )
- * </pre>
- * <ul>
- *   <li><b>floor 0.05</b> — never zero, so a query-time multiply never annihilates a hit.</li>
- *   <li><b>base</b> — feature-class prior (peak scales with elevation; place hierarchy city&gt;town&gt;
- *       village; national park; viewpoint/historic; water/spring; else a small baseline).</li>
- *   <li><b>qnorm</b> — log-normalized QRank (Wikimedia pageviews), only when a wikidata tag is present
- *       and found in the QRank table; 0 otherwise. {@code log(qrank)/log(QRANK_REF)} clamped to [0,1].</li>
- *   <li><b>meta</b> — richness: presence of image / website / wikipedia(=wikidata) tags.</li>
- * </ul>
- *
- * <p>Pure and side-effect-free so it is unit-testable without planetiler/ES.
- */
 final class ProminenceCalculator {
 
-  /** QRank reference ceiling for log-normalization — a realistic famous-place QRank. Calibrate. */
   static final double QRANK_REF = 3_000_000.0;
-  /** Highest summit on Earth (m), used to normalize elevation. */
   static final double MAX_ELE_M = 8849.0;
-  /** Floor so prominence is never 0 (a 0 would zero out a multiply). */
   static final double FLOOR = 0.05;
 
   private ProminenceCalculator() {}
 
-  /** Result holder carrying the final score plus raw components (stored index:false for re-tuning). */
   static final class Result {
     final float prominence;
     final float base;
@@ -50,19 +26,6 @@ final class ProminenceCalculator {
     }
   }
 
-  /**
-   * @param naturalTag  value of the OSM {@code natural} tag (peak/spring/...), or null
-   * @param placeTag    value of the OSM {@code place} tag (city/town/village/...), or null
-   * @param boundaryTag value of the OSM {@code boundary} tag (national_park/protected_area/...), or null
-   * @param tourismTag  value of the OSM {@code tourism} tag (viewpoint/attraction/...), or null
-   * @param historicTag value of the OSM {@code historic} tag, or null
-   * @param waterwayTag value of the OSM {@code waterway} tag, or null
-   * @param ele         parsed elevation in meters, or Double.NaN if absent
-   * @param hasImage    image / wikimedia_commons tag present
-   * @param hasWebsite  website tag present
-   * @param hasWikidata wikidata tag present (proxy for "documented in wikipedia/wikidata")
-   * @param qrankRaw    raw QRank value (0 if absent/unknown)
-   */
   static Result compute(String naturalTag, String placeTag, String boundaryTag, String tourismTag,
       String historicTag, String waterwayTag, double ele, boolean hasImage, boolean hasWebsite,
       boolean hasWikidata, long qrankRaw) {
@@ -70,7 +33,7 @@ final class ProminenceCalculator {
     double eleNorm = Double.isNaN(ele) ? 0.0 : clamp01(Math.log1p(Math.max(0, ele)) / Math.log1p(MAX_ELE_M));
     double base = baseScore(naturalTag, placeTag, boundaryTag, tourismTag, historicTag, waterwayTag, eleNorm);
 
-    double qnorm = (qrankRaw <= 1) ? 0.0 : clamp01(Math.log(qrankRaw) / Math.log(QRANK_REF));
+    double qnorm = (!hasWikidata || qrankRaw <= 1) ? 0.0 : clamp01(Math.log(qrankRaw) / Math.log(QRANK_REF));
 
     double meta = clamp01(0.40 * (hasImage ? 1 : 0) + 0.35 * (hasWebsite ? 1 : 0) + 0.25 * (hasWikidata ? 1 : 0));
 
@@ -79,11 +42,10 @@ final class ProminenceCalculator {
     return new Result((float) prom, (float) base, (float) qnorm, (float) meta, (float) eleNorm, qrankRaw);
   }
 
-  /** Feature-class prior in [0,1]. Highest signal wins (a place that is also a peak gets the peak rule). */
   private static double baseScore(String natural, String place, String boundary, String tourism,
       String historic, String waterway, double eleNorm) {
     if ("peak".equals(natural) || "volcano".equals(natural)) {
-      return 0.30 + 0.55 * eleNorm; // elevation-aware: a 4000m peak >> a 200m hill
+      return 0.30 + 0.55 * eleNorm;
     }
     if (place != null) {
       switch (place) {
@@ -91,7 +53,7 @@ final class ProminenceCalculator {
         case "town":      return 0.80;
         case "village":   return 0.55;
         case "hamlet":    return 0.35;
-        default:          return 0.45; // suburb/neighbourhood/locality/...
+        default:          return 0.45;
       }
     }
     if ("national_park".equals(boundary) || "protected_area".equals(boundary)) {
@@ -101,13 +63,13 @@ final class ProminenceCalculator {
       return 0.55;
     }
     if (historic != null) {
-      return 0.55; // ruins, archaeological_site, monument, memorial, castle...
+      return 0.55;
     }
     if ("spring".equals(natural) || "hot_spring".equals(natural) || "cave_entrance".equals(natural)
         || waterway != null) {
       return 0.30;
     }
-    return 0.25; // generic named node baseline
+    return 0.25;
   }
 
   static double clamp01(double v) {

--- a/src/main/java/il/org/osm/israelhiking/ProminenceCalculator.java
+++ b/src/main/java/il/org/osm/israelhiking/ProminenceCalculator.java
@@ -1,0 +1,118 @@
+package il.org.osm.israelhiking;
+
+/**
+ * Computes a composite {@code poiProminence} score in [0,1] for a feature, used at query time as a
+ * {@code field_value_factor} multiplier so a major peak / well-known place outranks an obscure node
+ * with the same name.
+ *
+ * <p>Formula (research-derived):
+ * <pre>
+ *   poiProminence = clamp01( 0.05 + 0.45*base + 0.40*qnorm + 0.10*meta )
+ * </pre>
+ * <ul>
+ *   <li><b>floor 0.05</b> — never zero, so a query-time multiply never annihilates a hit.</li>
+ *   <li><b>base</b> — feature-class prior (peak scales with elevation; place hierarchy city&gt;town&gt;
+ *       village; national park; viewpoint/historic; water/spring; else a small baseline).</li>
+ *   <li><b>qnorm</b> — log-normalized QRank (Wikimedia pageviews), only when a wikidata tag is present
+ *       and found in the QRank table; 0 otherwise. {@code log(qrank)/log(QRANK_REF)} clamped to [0,1].</li>
+ *   <li><b>meta</b> — richness: presence of image / website / wikipedia(=wikidata) tags.</li>
+ * </ul>
+ *
+ * <p>Pure and side-effect-free so it is unit-testable without planetiler/ES.
+ */
+final class ProminenceCalculator {
+
+  /** QRank reference ceiling for log-normalization — a realistic famous-place QRank. Calibrate. */
+  static final double QRANK_REF = 3_000_000.0;
+  /** Highest summit on Earth (m), used to normalize elevation. */
+  static final double MAX_ELE_M = 8849.0;
+  /** Floor so prominence is never 0 (a 0 would zero out a multiply). */
+  static final double FLOOR = 0.05;
+
+  private ProminenceCalculator() {}
+
+  /** Result holder carrying the final score plus raw components (stored index:false for re-tuning). */
+  static final class Result {
+    final float prominence;
+    final float base;
+    final float qrankNorm;
+    final float meta;
+    final float eleNorm;
+    final long qrankRaw;
+
+    Result(float prominence, float base, float qrankNorm, float meta, float eleNorm, long qrankRaw) {
+      this.prominence = prominence;
+      this.base = base;
+      this.qrankNorm = qrankNorm;
+      this.meta = meta;
+      this.eleNorm = eleNorm;
+      this.qrankRaw = qrankRaw;
+    }
+  }
+
+  /**
+   * @param naturalTag  value of the OSM {@code natural} tag (peak/spring/...), or null
+   * @param placeTag    value of the OSM {@code place} tag (city/town/village/...), or null
+   * @param boundaryTag value of the OSM {@code boundary} tag (national_park/protected_area/...), or null
+   * @param tourismTag  value of the OSM {@code tourism} tag (viewpoint/attraction/...), or null
+   * @param historicTag value of the OSM {@code historic} tag, or null
+   * @param waterwayTag value of the OSM {@code waterway} tag, or null
+   * @param ele         parsed elevation in meters, or Double.NaN if absent
+   * @param hasImage    image / wikimedia_commons tag present
+   * @param hasWebsite  website tag present
+   * @param hasWikidata wikidata tag present (proxy for "documented in wikipedia/wikidata")
+   * @param qrankRaw    raw QRank value (0 if absent/unknown)
+   */
+  static Result compute(String naturalTag, String placeTag, String boundaryTag, String tourismTag,
+      String historicTag, String waterwayTag, double ele, boolean hasImage, boolean hasWebsite,
+      boolean hasWikidata, long qrankRaw) {
+
+    double eleNorm = Double.isNaN(ele) ? 0.0 : clamp01(Math.log1p(Math.max(0, ele)) / Math.log1p(MAX_ELE_M));
+    double base = baseScore(naturalTag, placeTag, boundaryTag, tourismTag, historicTag, waterwayTag, eleNorm);
+
+    double qnorm = (qrankRaw <= 1) ? 0.0 : clamp01(Math.log(qrankRaw) / Math.log(QRANK_REF));
+
+    double meta = clamp01(0.40 * (hasImage ? 1 : 0) + 0.35 * (hasWebsite ? 1 : 0) + 0.25 * (hasWikidata ? 1 : 0));
+
+    double prom = clamp01(FLOOR + 0.45 * base + 0.40 * qnorm + 0.10 * meta);
+
+    return new Result((float) prom, (float) base, (float) qnorm, (float) meta, (float) eleNorm, qrankRaw);
+  }
+
+  /** Feature-class prior in [0,1]. Highest signal wins (a place that is also a peak gets the peak rule). */
+  private static double baseScore(String natural, String place, String boundary, String tourism,
+      String historic, String waterway, double eleNorm) {
+    if ("peak".equals(natural) || "volcano".equals(natural)) {
+      return 0.30 + 0.55 * eleNorm; // elevation-aware: a 4000m peak >> a 200m hill
+    }
+    if (place != null) {
+      switch (place) {
+        case "city":      return 1.00;
+        case "town":      return 0.80;
+        case "village":   return 0.55;
+        case "hamlet":    return 0.35;
+        default:          return 0.45; // suburb/neighbourhood/locality/...
+      }
+    }
+    if ("national_park".equals(boundary) || "protected_area".equals(boundary)) {
+      return 0.80;
+    }
+    if ("viewpoint".equals(tourism) || "attraction".equals(tourism) || "alpine_hut".equals(tourism)) {
+      return 0.55;
+    }
+    if (historic != null) {
+      return 0.55; // ruins, archaeological_site, monument, memorial, castle...
+    }
+    if ("spring".equals(natural) || "hot_spring".equals(natural) || "cave_entrance".equals(natural)
+        || waterway != null) {
+      return 0.30;
+    }
+    return 0.25; // generic named node baseline
+  }
+
+  static double clamp01(double v) {
+    if (v < 0) return 0;
+    if (v > 1) return 1;
+    return v;
+  }
+}

--- a/src/main/java/il/org/osm/israelhiking/QRankIndex.java
+++ b/src/main/java/il/org/osm/israelhiking/QRankIndex.java
@@ -1,0 +1,103 @@
+package il.org.osm.israelhiking;
+
+import com.carrotsearch.hppc.LongIntHashMap;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Logger;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * In-memory lookup of QRank (Wikimedia pageview rank) by Wikidata Q-id.
+ *
+ * <p>QRank (https://qrank.toolforge.org, CC0) ranks Wikidata entities by aggregated Wikimedia
+ * pageviews — a strong "how much do people look this up" signal, better aligned with an outdoor
+ * product than Wikipedia-inlink importance. The file {@code qrank.csv.gz} has a header
+ * {@code Entity,QRank} and ~28.7M rows like {@code Q665321,1234567}.
+ *
+ * <p>Backed by carrotsearch HPPC {@link LongIntHashMap} (a planetiler-bundled dependency — no new
+ * pom entry). QRank's max (~559M) fits an {@code int}. ~28.7M entries ≈ 0.4–0.6 GB resident.
+ *
+ * <p>The {@link #load(Path)} factory accepts a null/missing/empty path and returns an EMPTY index
+ * whose lookups all return 0 — the escape hatch for local testing on a Geofabrik extract without
+ * shipping the 363 MB file. The map is built once before the planetiler pass and only read
+ * (concurrently, safely) during it.
+ */
+class QRankIndex {
+  private static final Logger LOGGER = Logger.getLogger(QRankIndex.class.getName());
+
+  private final LongIntHashMap qrankByQid;
+
+  private QRankIndex(LongIntHashMap qrankByQid) {
+    this.qrankByQid = qrankByQid;
+  }
+
+  /** An empty index — every lookup returns 0. Used when no QRank file is provided. */
+  static QRankIndex empty() {
+    return new QRankIndex(new LongIntHashMap(0));
+  }
+
+  /**
+   * Load a gzipped {@code qrank.csv.gz}. If {@code csvGz} is null, missing, or empty, returns an
+   * empty index (no exception) so local builds can run without the file.
+   */
+  static QRankIndex load(Path csvGz) {
+    if (csvGz == null || !Files.isRegularFile(csvGz)) {
+      LOGGER.info("QRankIndex: no QRank file provided — running with an empty index (lookups return 0)");
+      return empty();
+    }
+    long startMs = System.currentTimeMillis();
+    LongIntHashMap map = new LongIntHashMap(32_000_000);
+    long rows = 0;
+    try (InputStream fis = Files.newInputStream(csvGz);
+        GZIPInputStream gz = new GZIPInputStream(fis, 1 << 16);
+        BufferedReader br = new BufferedReader(new InputStreamReader(gz, StandardCharsets.UTF_8), 1 << 20)) {
+      String line = br.readLine(); // header: Entity,QRank
+      while ((line = br.readLine()) != null) {
+        int comma = line.indexOf(',');
+        if (comma <= 1 || line.charAt(0) != 'Q') {
+          continue; // skip malformed / non-Q rows
+        }
+        try {
+          long qid = Long.parseLong(line, 1, comma, 10); // skip the leading 'Q', no substring alloc
+          int qrank = Integer.parseInt(line, comma + 1, line.length(), 10);
+          map.put(qid, qrank);
+          rows++;
+        } catch (NumberFormatException ignored) {
+          // a stray line that doesn't parse — skip it, never fail the build
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.warning("QRankIndex: failed to read " + csvGz + " (" + e.getMessage()
+          + ") — continuing with whatever loaded (" + rows + " rows)");
+    }
+    long heapMb = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / (1024 * 1024);
+    LOGGER.info("QRankIndex: loaded " + rows + " rows from " + csvGz
+        + " in " + (System.currentTimeMillis() - startMs) + "ms (heap used ~" + heapMb + " MB)");
+    return new QRankIndex(map);
+  }
+
+  /**
+   * Raw QRank for an OSM {@code wikidata} tag value (e.g. {@code "Q665321"}), or 0 if the tag is
+   * absent, malformed, or not in the table.
+   */
+  long getByWikidata(String wikidata) {
+    if (wikidata == null || wikidata.length() < 2 || wikidata.charAt(0) != 'Q') {
+      return 0;
+    }
+    try {
+      long qid = Long.parseLong(wikidata, 1, wikidata.length(), 10);
+      return qrankByQid.getOrDefault(qid, 0);
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  int size() {
+    return qrankByQid.size();
+  }
+}

--- a/src/main/java/il/org/osm/israelhiking/QRankIndex.java
+++ b/src/main/java/il/org/osm/israelhiking/QRankIndex.java
@@ -11,22 +11,6 @@ import java.nio.file.Path;
 import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
 
-/**
- * In-memory lookup of QRank (Wikimedia pageview rank) by Wikidata Q-id.
- *
- * <p>QRank (https://qrank.toolforge.org, CC0) ranks Wikidata entities by aggregated Wikimedia
- * pageviews — a strong "how much do people look this up" signal, better aligned with an outdoor
- * product than Wikipedia-inlink importance. The file {@code qrank.csv.gz} has a header
- * {@code Entity,QRank} and ~28.7M rows like {@code Q665321,1234567}.
- *
- * <p>Backed by carrotsearch HPPC {@link LongIntHashMap} (a planetiler-bundled dependency — no new
- * pom entry). QRank's max (~559M) fits an {@code int}. ~28.7M entries ≈ 0.4–0.6 GB resident.
- *
- * <p>The {@link #load(Path)} factory accepts a null/missing/empty path and returns an EMPTY index
- * whose lookups all return 0 — the escape hatch for local testing on a Geofabrik extract without
- * shipping the 363 MB file. The map is built once before the planetiler pass and only read
- * (concurrently, safely) during it.
- */
 class QRankIndex {
   private static final Logger LOGGER = Logger.getLogger(QRankIndex.class.getName());
 
@@ -36,15 +20,10 @@ class QRankIndex {
     this.qrankByQid = qrankByQid;
   }
 
-  /** An empty index — every lookup returns 0. Used when no QRank file is provided. */
   static QRankIndex empty() {
     return new QRankIndex(new LongIntHashMap(0));
   }
 
-  /**
-   * Load a gzipped {@code qrank.csv.gz}. If {@code csvGz} is null, missing, or empty, returns an
-   * empty index (no exception) so local builds can run without the file.
-   */
   static QRankIndex load(Path csvGz) {
     if (csvGz == null || !Files.isRegularFile(csvGz)) {
       LOGGER.info("QRankIndex: no QRank file provided — running with an empty index (lookups return 0)");
@@ -56,19 +35,18 @@ class QRankIndex {
     try (InputStream fis = Files.newInputStream(csvGz);
         GZIPInputStream gz = new GZIPInputStream(fis, 1 << 16);
         BufferedReader br = new BufferedReader(new InputStreamReader(gz, StandardCharsets.UTF_8), 1 << 20)) {
-      String line = br.readLine(); // header: Entity,QRank
+      String line = br.readLine();
       while ((line = br.readLine()) != null) {
         int comma = line.indexOf(',');
         if (comma <= 1 || line.charAt(0) != 'Q') {
-          continue; // skip malformed / non-Q rows
+          continue;
         }
         try {
-          long qid = Long.parseLong(line, 1, comma, 10); // skip the leading 'Q', no substring alloc
+          long qid = Long.parseLong(line, 1, comma, 10);
           int qrank = Integer.parseInt(line, comma + 1, line.length(), 10);
           map.put(qid, qrank);
           rows++;
         } catch (NumberFormatException ignored) {
-          // a stray line that doesn't parse — skip it, never fail the build
         }
       }
     } catch (Exception e) {
@@ -81,10 +59,6 @@ class QRankIndex {
     return new QRankIndex(map);
   }
 
-  /**
-   * Raw QRank for an OSM {@code wikidata} tag value (e.g. {@code "Q665321"}), or 0 if the tag is
-   * absent, malformed, or not in the table.
-   */
   long getByWikidata(String wikidata) {
     if (wikidata == null || wikidata.length() < 2 || wikidata.charAt(0) != 'Q') {
       return 0;

--- a/src/test/java/il/org/osm/israelhiking/BulkIngesterAccountingTest.java
+++ b/src/test/java/il/org/osm/israelhiking/BulkIngesterAccountingTest.java
@@ -27,24 +27,6 @@ import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 import co.elastic.clients.elasticsearch.core.bulk.OperationType;
 
-/**
- * Regression guard for the lossless BulkIngester indexing invariant.
- *
- * <p>The production listener is {@link PlanetSearchProfile.AccountingBulkListener}. Driving its
- * {@code afterBulk} overloads directly lets us assert, deterministically and without a live
- * Elasticsearch, that:
- * <ol>
- *   <li>a bulk item failure is <em>surfaced</em> (counted and logged at WARNING), never swallowed;
- *       the success path increments indexedCount.</li>
- *   <li>lossless accounting: every item the listener sees is classified as exactly one of
- *       indexed / failed, so indexed + failed == items submitted.</li>
- *   <li>a whole-batch failure (the {@code Throwable} overload) adds the entire batch to the failed
- *       buckets (classified by destination index) and is logged at SEVERE, and the fail-the-build
- *       decision is taken.</li>
- *   <li>points failures trip {@code hasIndexingFailures()} while bbox geo_shape rejects do not
- *       (warn-only).</li>
- * </ol>
- */
 @Tag("unit")
 @ExtendWith(MockitoExtension.class)
 class BulkIngesterAccountingTest {
@@ -67,10 +49,8 @@ class BulkIngesterAccountingTest {
         failedPointsCount = new LongAdder();
         failedBboxCount = new LongAdder();
         listener = new PlanetSearchProfile.AccountingBulkListener(
-                indexedCount, failedPointsCount, failedBboxCount, POINTS_INDEX);
+                indexedCount, failedPointsCount, failedBboxCount, BBOX_INDEX);
 
-        // Capture log records so "surfaced" can be asserted (logged AND counted),
-        // proving the old catch(Exception){/*swallow*/} pattern is gone.
         profileLogger = Logger.getLogger(PlanetSearchProfile.class.getName());
         previousLevel = profileLogger.getLevel();
         profileLogger.setLevel(Level.ALL);
@@ -84,11 +64,9 @@ class BulkIngesterAccountingTest {
         profileLogger.setLevel(previousLevel);
     }
 
-    // ---- a bulk item failure is surfaced via the counter, not swallowed ----
-
     @Test
     void afterBulk_withItemError_incrementsFailedCountAndLogsWarning() {
-        BulkResponseItem failedItem = item("bad-1", /* withError */ true);
+        BulkResponseItem failedItem = item("bad-1", true);
         BulkResponse response = responseWithErrors(List.of(failedItem));
 
         listener.afterBulk(1L, emptyRequest(), Collections.emptyList(), response);
@@ -101,7 +79,6 @@ class BulkIngesterAccountingTest {
 
     @Test
     void afterBulk_successPath_incrementsIndexedCount() {
-        // errors()==false: the listener fast-paths the whole batch as indexed.
         BulkResponse response = BulkResponse.of(b -> b
                 .took(5)
                 .errors(false)
@@ -115,7 +92,6 @@ class BulkIngesterAccountingTest {
 
     @Test
     void afterBulk_mixedBatch_classifiesEachItemExactlyOnce() {
-        // errors()==true with a mix: per-item branch counts failures and successes.
         List<BulkResponseItem> items = List.of(
                 item("ok-1", false),
                 item("bad-1", true),
@@ -129,15 +105,12 @@ class BulkIngesterAccountingTest {
         assertEquals(2, totalFailed());
     }
 
-    // ---- lossless accounting — emitted == indexed + failed ----
-
     @Test
     void losslessAccounting_indexedPlusFailedEqualsItemsSubmitted() {
-        // A controlled "emitted" batch of 10, two of which fail at the item level.
         int emitted = 10;
         List<BulkResponseItem> items = new ArrayList<>();
         for (int i = 0; i < emitted; i++) {
-            items.add(item("doc-" + i, /* fail items 3 and 7 */ i == 3 || i == 7));
+            items.add(item("doc-" + i, i == 3 || i == 7));
         }
         BulkResponse response = responseWithErrors(items);
 
@@ -147,12 +120,8 @@ class BulkIngesterAccountingTest {
         long failed = totalFailed();
         assertEquals(8, indexed);
         assertEquals(2, failed);
-        // The lossless invariant: every emitted/attempted doc is accounted for as
-        // exactly one of indexed or failed — nothing silently disappears.
         assertEquals(emitted, indexed + failed, "emitted must equal indexed + failed");
     }
-
-    // ---- an unrecoverable error is not mistaken for success ----
 
     @Test
     void afterBulk_wholeBatchThrowable_addsBatchSizeToFailedAndLogsSevere() {
@@ -164,7 +133,6 @@ class BulkIngesterAccountingTest {
 
         assertEquals(batchSize, totalFailed(),
                 "whole-batch failure must add the entire request size to failedCount");
-        // The request targets the points index, so the whole batch is classified as points failures.
         assertEquals(batchSize, failedPointsCount.sum(),
                 "a points-targeted whole-batch failure must land in failedPointsCount");
         assertEquals(0, indexedCount.sum());
@@ -174,27 +142,17 @@ class BulkIngesterAccountingTest {
 
     @Test
     void failBuildDecision_isTakenWhenPointsDocFailed_andNotOnCleanRun() {
-        // MainClass.run gates its non-zero exit on PlanetSearchProfile.hasIndexingFailures(),
-        // a pure predicate == (failedPointsCount > 0). Modelling it directly over the listener's
-        // counters keeps the exit decision unit-testable without calling System.exit.
         assertFalse(failsBuild(), "a clean run (no failures) must NOT fail the build");
 
-        // A whole-batch unrecoverable failure on the points index records points failures...
         listener.afterBulk(6L, requestWithOperations(3, POINTS_INDEX), Collections.emptyList(),
                 new RuntimeException("boom"));
 
-        // ...so the fail-the-build decision must now be taken (CI cannot green a partial points index).
         assertTrue(failsBuild(),
                 "once any POINTS document fails, the build must fail (no partial index mistaken for success)");
     }
 
-    // ---- points-vs-bbox classification: bbox geo_shape rejects are warn-only ----
-
     @Test
     void bboxItemFailures_areCountedSeparately_andDoNotFailTheBuild() {
-        // The real-world case: a few degenerate OSM relation geometries ES rejects with
-        // "failed to parse field [bbox] of type [geo_shape]". They must be surfaced and
-        // counted (lossless), but must NOT trip the build — they don't affect name search.
         List<BulkResponseItem> items = List.of(
                 item(BBOX_INDEX, "rel-1", true),
                 item(BBOX_INDEX, "rel-2", true),
@@ -220,10 +178,6 @@ class BulkIngesterAccountingTest {
         return failedPointsCount.sum() + failedBboxCount.sum();
     }
 
-    // ---------------------------------------------------------------------------
-    // Helpers
-    // ---------------------------------------------------------------------------
-
     private static BulkResponse responseWithErrors(List<BulkResponseItem> items) {
         return BulkResponse.of(b -> b.took(5).errors(true).items(items));
     }
@@ -243,8 +197,7 @@ class BulkIngesterAccountingTest {
     }
 
     private static BulkRequest emptyRequest() {
-        // The BulkResponse overload of afterBulk never reads the request; the 8.x
-        // BulkRequest builder still requires a non-empty operations list, so supply one.
+        // The 8.x BulkRequest builder rejects an empty operations list, so supply one even though this overload never reads it.
         return requestWithOperations(1, POINTS_INDEX);
     }
 
@@ -267,8 +220,6 @@ class BulkIngesterAccountingTest {
     }
 
     private static String formatted(LogRecord r) {
-        // The production code logs via Supplier<String>; LogRecord.getMessage()
-        // already resolves it for these java.util.logging calls.
         return r.getMessage() == null ? "" : r.getMessage();
     }
 

--- a/src/test/java/il/org/osm/israelhiking/BulkIngesterAccountingTest.java
+++ b/src/test/java/il/org/osm/israelhiking/BulkIngesterAccountingTest.java
@@ -1,0 +1,291 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import co.elastic.clients.elasticsearch.core.bulk.OperationType;
+
+/**
+ * Regression guard for the lossless BulkIngester indexing invariant.
+ *
+ * <p>The production listener is {@link PlanetSearchProfile.AccountingBulkListener}. Driving its
+ * {@code afterBulk} overloads directly lets us assert, deterministically and without a live
+ * Elasticsearch, that:
+ * <ol>
+ *   <li>a bulk item failure is <em>surfaced</em> (counted and logged at WARNING), never swallowed;
+ *       the success path increments indexedCount.</li>
+ *   <li>lossless accounting: every item the listener sees is classified as exactly one of
+ *       indexed / failed, so indexed + failed == items submitted.</li>
+ *   <li>a whole-batch failure (the {@code Throwable} overload) adds the entire batch to the failed
+ *       buckets (classified by destination index) and is logged at SEVERE, and the fail-the-build
+ *       decision is taken.</li>
+ *   <li>points failures trip {@code hasIndexingFailures()} while bbox geo_shape rejects do not
+ *       (warn-only).</li>
+ * </ol>
+ */
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+class BulkIngesterAccountingTest {
+
+    private static final String POINTS_INDEX = "points";
+    private static final String BBOX_INDEX = "bbox";
+
+    private LongAdder indexedCount;
+    private LongAdder failedPointsCount;
+    private LongAdder failedBboxCount;
+    private PlanetSearchProfile.AccountingBulkListener listener;
+
+    private Logger profileLogger;
+    private RecordingHandler handler;
+    private Level previousLevel;
+
+    @BeforeEach
+    void setUp() {
+        indexedCount = new LongAdder();
+        failedPointsCount = new LongAdder();
+        failedBboxCount = new LongAdder();
+        listener = new PlanetSearchProfile.AccountingBulkListener(
+                indexedCount, failedPointsCount, failedBboxCount, POINTS_INDEX);
+
+        // Capture log records so "surfaced" can be asserted (logged AND counted),
+        // proving the old catch(Exception){/*swallow*/} pattern is gone.
+        profileLogger = Logger.getLogger(PlanetSearchProfile.class.getName());
+        previousLevel = profileLogger.getLevel();
+        profileLogger.setLevel(Level.ALL);
+        handler = new RecordingHandler();
+        profileLogger.addHandler(handler);
+    }
+
+    @AfterEach
+    void tearDown() {
+        profileLogger.removeHandler(handler);
+        profileLogger.setLevel(previousLevel);
+    }
+
+    // ---- a bulk item failure is surfaced via the counter, not swallowed ----
+
+    @Test
+    void afterBulk_withItemError_incrementsFailedCountAndLogsWarning() {
+        BulkResponseItem failedItem = item("bad-1", /* withError */ true);
+        BulkResponse response = responseWithErrors(List.of(failedItem));
+
+        listener.afterBulk(1L, emptyRequest(), Collections.emptyList(), response);
+
+        assertEquals(1, totalFailed(), "item with non-null error() must be counted as failed");
+        assertEquals(0, indexedCount.sum(), "a failed item must not be counted as indexed");
+        assertTrue(loggedAtLeast(Level.WARNING, "Failed to index id=bad-1"),
+                "the failure must be logged (surfaced), not swallowed");
+    }
+
+    @Test
+    void afterBulk_successPath_incrementsIndexedCount() {
+        // errors()==false: the listener fast-paths the whole batch as indexed.
+        BulkResponse response = BulkResponse.of(b -> b
+                .took(5)
+                .errors(false)
+                .items(List.of(item("ok-1", false), item("ok-2", false), item("ok-3", false))));
+
+        listener.afterBulk(2L, emptyRequest(), Collections.emptyList(), response);
+
+        assertEquals(3, indexedCount.sum());
+        assertEquals(0, totalFailed());
+    }
+
+    @Test
+    void afterBulk_mixedBatch_classifiesEachItemExactlyOnce() {
+        // errors()==true with a mix: per-item branch counts failures and successes.
+        List<BulkResponseItem> items = List.of(
+                item("ok-1", false),
+                item("bad-1", true),
+                item("ok-2", false),
+                item("bad-2", true));
+        BulkResponse response = responseWithErrors(items);
+
+        listener.afterBulk(3L, emptyRequest(), Collections.emptyList(), response);
+
+        assertEquals(2, indexedCount.sum());
+        assertEquals(2, totalFailed());
+    }
+
+    // ---- lossless accounting — emitted == indexed + failed ----
+
+    @Test
+    void losslessAccounting_indexedPlusFailedEqualsItemsSubmitted() {
+        // A controlled "emitted" batch of 10, two of which fail at the item level.
+        int emitted = 10;
+        List<BulkResponseItem> items = new ArrayList<>();
+        for (int i = 0; i < emitted; i++) {
+            items.add(item("doc-" + i, /* fail items 3 and 7 */ i == 3 || i == 7));
+        }
+        BulkResponse response = responseWithErrors(items);
+
+        listener.afterBulk(4L, emptyRequest(), Collections.emptyList(), response);
+
+        long indexed = indexedCount.sum();
+        long failed = totalFailed();
+        assertEquals(8, indexed);
+        assertEquals(2, failed);
+        // The lossless invariant: every emitted/attempted doc is accounted for as
+        // exactly one of indexed or failed — nothing silently disappears.
+        assertEquals(emitted, indexed + failed, "emitted must equal indexed + failed");
+    }
+
+    // ---- an unrecoverable error is not mistaken for success ----
+
+    @Test
+    void afterBulk_wholeBatchThrowable_addsBatchSizeToFailedAndLogsSevere() {
+        int batchSize = 7;
+        BulkRequest request = requestWithOperations(batchSize);
+
+        listener.afterBulk(5L, request, Collections.emptyList(),
+                new RuntimeException("connection reset"));
+
+        assertEquals(batchSize, totalFailed(),
+                "whole-batch failure must add the entire request size to failedCount");
+        // The request targets the points index, so the whole batch is classified as points failures.
+        assertEquals(batchSize, failedPointsCount.sum(),
+                "a points-targeted whole-batch failure must land in failedPointsCount");
+        assertEquals(0, indexedCount.sum());
+        assertTrue(loggedAtLeast(Level.SEVERE, "failed entirely"),
+                "an unrecoverable whole-batch error must be logged at SEVERE");
+    }
+
+    @Test
+    void failBuildDecision_isTakenWhenPointsDocFailed_andNotOnCleanRun() {
+        // MainClass.run gates its non-zero exit on PlanetSearchProfile.hasIndexingFailures(),
+        // a pure predicate == (failedPointsCount > 0). Modelling it directly over the listener's
+        // counters keeps the exit decision unit-testable without calling System.exit.
+        assertFalse(failsBuild(), "a clean run (no failures) must NOT fail the build");
+
+        // A whole-batch unrecoverable failure on the points index records points failures...
+        listener.afterBulk(6L, requestWithOperations(3, POINTS_INDEX), Collections.emptyList(),
+                new RuntimeException("boom"));
+
+        // ...so the fail-the-build decision must now be taken (CI cannot green a partial points index).
+        assertTrue(failsBuild(),
+                "once any POINTS document fails, the build must fail (no partial index mistaken for success)");
+    }
+
+    // ---- points-vs-bbox classification: bbox geo_shape rejects are warn-only ----
+
+    @Test
+    void bboxItemFailures_areCountedSeparately_andDoNotFailTheBuild() {
+        // The real-world case: a few degenerate OSM relation geometries ES rejects with
+        // "failed to parse field [bbox] of type [geo_shape]". They must be surfaced and
+        // counted (lossless), but must NOT trip the build — they don't affect name search.
+        List<BulkResponseItem> items = List.of(
+                item(BBOX_INDEX, "rel-1", true),
+                item(BBOX_INDEX, "rel-2", true),
+                item(POINTS_INDEX, "ok-1", false));
+        BulkResponse response = responseWithErrors(items);
+
+        listener.afterBulk(7L, emptyRequest(), Collections.emptyList(), response);
+
+        assertEquals(2, failedBboxCount.sum(), "bbox rejects must be counted in the bbox bucket");
+        assertEquals(0, failedPointsCount.sum(), "no points doc failed");
+        assertEquals(1, indexedCount.sum());
+        assertEquals(2, totalFailed(), "lossless: bbox failures are still counted in the total");
+        assertFalse(failsBuild(), "bbox-only failures must NOT fail the build (warn-only)");
+    }
+
+    /** Mirrors PlanetSearchProfile.hasIndexingFailures(): failedPointsCount.sum() > 0. */
+    private boolean failsBuild() {
+        return failedPointsCount.sum() > 0;
+    }
+
+    /** Mirrors PlanetSearchProfile.getFailedCount(): points + bbox (the lossless total). */
+    private long totalFailed() {
+        return failedPointsCount.sum() + failedBboxCount.sum();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private static BulkResponse responseWithErrors(List<BulkResponseItem> items) {
+        return BulkResponse.of(b -> b.took(5).errors(true).items(items));
+    }
+
+    private static BulkResponseItem item(String id, boolean withError) {
+        return item(POINTS_INDEX, id, withError);
+    }
+
+    private static BulkResponseItem item(String index, String id, boolean withError) {
+        return BulkResponseItem.of(b -> {
+            b.operationType(OperationType.Index).index(index).id(id).status(withError ? 400 : 200);
+            if (withError) {
+                b.error(e -> e.type("mapper_parsing_exception").reason("bad doc " + id));
+            }
+            return b;
+        });
+    }
+
+    private static BulkRequest emptyRequest() {
+        // The BulkResponse overload of afterBulk never reads the request; the 8.x
+        // BulkRequest builder still requires a non-empty operations list, so supply one.
+        return requestWithOperations(1, POINTS_INDEX);
+    }
+
+    private static BulkRequest requestWithOperations(int n) {
+        return requestWithOperations(n, POINTS_INDEX);
+    }
+
+    private static BulkRequest requestWithOperations(int n, String index) {
+        List<BulkOperation> ops = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            final int idx = i;
+            ops.add(BulkOperation.of(op -> op.index(ix -> ix.index(index).id("op-" + idx).document(Map.of("k", idx)))));
+        }
+        return BulkRequest.of(b -> b.operations(ops));
+    }
+
+    private boolean loggedAtLeast(Level level, String substring) {
+        return handler.records.stream()
+                .anyMatch(r -> r.getLevel() == level && formatted(r).contains(substring));
+    }
+
+    private static String formatted(LogRecord r) {
+        // The production code logs via Supplier<String>; LogRecord.getMessage()
+        // already resolves it for these java.util.logging calls.
+        return r.getMessage() == null ? "" : r.getMessage();
+    }
+
+    private static final class RecordingHandler extends Handler {
+        private final List<LogRecord> records = Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/EmittedCountInvariantTest.java
+++ b/src/test/java/il/org/osm/israelhiking/EmittedCountInvariantTest.java
@@ -83,7 +83,7 @@ class EmittedCountInvariantTest {
         ElasticsearchClient esClient = mock(ElasticsearchClient.class);
         when(esClient._transport()).thenReturn(transport);
         ElasticRunContext context = new ElasticRunContext(
-                esClient, "points", "bbox", POINTS_TARGET, BBOX_TARGET, new String[] { "en" });
+                esClient, "points", "bbox", POINTS_TARGET, BBOX_TARGET, new String[] { "en" }, QRankIndex.empty());
 
         Constructor<PlanetSearchProfile> ctor = PlanetSearchProfile.class.getDeclaredConstructor(
                 com.onthegomap.planetiler.config.PlanetilerConfig.class, ElasticRunContext.class);

--- a/src/test/java/il/org/osm/israelhiking/EmittedCountInvariantTest.java
+++ b/src/test/java/il/org/osm/israelhiking/EmittedCountInvariantTest.java
@@ -1,0 +1,141 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import co.elastic.clients.elasticsearch.core.bulk.OperationType;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.TransportOptions;
+
+import il.org.osm.israelhiking.ElasticsearchHelper.ElasticRunContext;
+
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+class EmittedCountInvariantTest {
+
+    private static final String POINTS_TARGET = "points1";
+    private static final String BBOX_TARGET = "bbox1";
+
+    @Test
+    void eachInsertEmitsExactlyOnce_andEmittedEqualsIndexedPlusFailed() throws Exception {
+        int points = 5;
+        int bbox = 3;
+
+        PlanetSearchProfile profile = newProfile();
+
+        for (int i = 0; i < points; i++) {
+            insertPoint(profile, "OSM_node_" + i);
+        }
+        for (int i = 0; i < bbox; i++) {
+            insertBbox(profile);
+        }
+
+        assertEquals(points + bbox, profile.getEmittedCount(),
+                "each successful insert must increment emittedCount exactly once");
+
+        PlanetSearchProfile.AccountingBulkListener listener = listenerOver(profile);
+        List<BulkResponseItem> items = new ArrayList<>();
+        for (int i = 0; i < points; i++) {
+            items.add(item(POINTS_TARGET, "OSM_node_" + i, i == 1));
+        }
+        for (int i = 0; i < bbox; i++) {
+            items.add(item(BBOX_TARGET, "bbox-" + i, i == 0));
+        }
+        listener.afterBulk(1L, emptyRequest(), Collections.emptyList(),
+                BulkResponse.of(b -> b.took(1).errors(true).items(items)));
+
+        assertEquals(points + bbox, profile.getIndexedCount() + profile.getFailedCount(),
+                "every emitted doc must be accounted for as exactly one of indexed/failed");
+        assertEquals(profile.getEmittedCount(), profile.getIndexedCount() + profile.getFailedCount(),
+                "lossless invariant: emitted == indexed + failed");
+        assertEquals(1, profile.getFailedPointsCount(), "the failed points item lands in the points bucket");
+        assertEquals(1, profile.getFailedBboxCount(), "the failed bbox item lands in the bbox bucket");
+        assertTrue(profile.hasIndexingFailures(), "a dropped points doc must trip the fail-the-build gate");
+    }
+
+    private static PlanetSearchProfile newProfile() throws Exception {
+        // ElasticRunContext is a final record, so it can't be Mockito-mocked; wrap a mock client in a real one.
+        ElasticsearchTransport transport = mock(ElasticsearchTransport.class);
+        when(transport.options()).thenReturn(mock(TransportOptions.class));
+        // add() serializes the document eagerly, so it needs a real mapper.
+        when(transport.jsonpMapper()).thenReturn(new JacksonJsonpMapper());
+        ElasticsearchClient esClient = mock(ElasticsearchClient.class);
+        when(esClient._transport()).thenReturn(transport);
+        ElasticRunContext context = new ElasticRunContext(
+                esClient, "points", "bbox", POINTS_TARGET, BBOX_TARGET, new String[] { "en" });
+
+        Constructor<PlanetSearchProfile> ctor = PlanetSearchProfile.class.getDeclaredConstructor(
+                com.onthegomap.planetiler.config.PlanetilerConfig.class, ElasticRunContext.class);
+        ctor.setAccessible(true);
+        return ctor.newInstance(null, context);
+    }
+
+    private static void insertPoint(PlanetSearchProfile profile, String docId) throws Exception {
+        PointDocument doc = new PointDocument();
+        doc.location = new double[] { 35.0, 31.0 };
+        Method m = PlanetSearchProfile.class.getDeclaredMethod(
+                "insertPointToElasticsearch", PointDocument.class, String.class);
+        m.setAccessible(true);
+        m.invoke(profile, doc, docId);
+    }
+
+    private static void insertBbox(PlanetSearchProfile profile) throws Exception {
+        BBoxDocument bbox = new BBoxDocument();
+        bbox.center = new double[] { 35.0, 31.0 };
+        Method m = PlanetSearchProfile.class.getDeclaredMethod(
+                "addBboxToBulk", BBoxDocument.class, String.class);
+        m.setAccessible(true);
+        m.invoke(profile, bbox, "bbox-" + System.nanoTime());
+    }
+
+    private static PlanetSearchProfile.AccountingBulkListener listenerOver(PlanetSearchProfile profile)
+            throws Exception {
+        return new PlanetSearchProfile.AccountingBulkListener(
+                adder(profile, "indexedCount"),
+                adder(profile, "failedPointsCount"),
+                adder(profile, "failedBboxCount"),
+                BBOX_TARGET);
+    }
+
+    private static LongAdder adder(PlanetSearchProfile profile, String name) throws Exception {
+        Field f = PlanetSearchProfile.class.getDeclaredField(name);
+        f.setAccessible(true);
+        return (LongAdder) f.get(profile);
+    }
+
+    private static BulkResponseItem item(String index, String id, boolean withError) {
+        return BulkResponseItem.of(b -> {
+            b.operationType(OperationType.Index).index(index).id(id).status(withError ? 400 : 200);
+            if (withError) {
+                b.error(e -> e.type("mapper_parsing_exception").reason("bad doc " + id));
+            }
+            return b;
+        });
+    }
+
+    private static BulkRequest emptyRequest() {
+        return BulkRequest.of(b -> b.operations(
+                op -> op.index(ix -> ix.index(POINTS_TARGET).id("op-0").document(Map.of("k", 0)))));
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/InsertProminenceFloorTest.java
+++ b/src/test/java/il/org/osm/israelhiking/InsertProminenceFloorTest.java
@@ -1,0 +1,79 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Modifier;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the INSERT-path prominence safety floor (FR-B6).
+ *
+ * <p>This is distinct from {@code ProminenceCalculatorTest.prominenceIsNeverZero}, which guards the
+ * CALCULATOR floor. Some emit paths (ski-lift ways, relation-completion) never run
+ * {@code convertTagsToDocument}, so {@code pointDocument.poiProminence} arrives null at
+ * {@code insertPointToElasticsearch}. The insert-path floor must turn that null into
+ * {@code (float) ProminenceCalculator.FLOOR} (0.05) so it can't serialize as null —
+ * which, given {@code @JsonInclude(NON_NULL)}, would be OMITTED from _source -> field_value_factor
+ * {@code missing:1.0} -> the doc unfairly outranks a real, scored feature (poiProminence &lt; 1).
+ *
+ * <p>The floored logic was extracted to the package-private static {@code flooredProminence(Float)}
+ * (a behavior-preserving refactor — no contract/API change) so it can be unit-tested without
+ * touching the private {@code insertPointToElasticsearch} / its real {@code BulkIngester}. No mock
+ * is needed: the helper is pure.
+ */
+@Tag("unit")
+public class InsertProminenceFloorTest {
+
+    @Test
+    public void nullProminenceIsFlooredToFloor() {
+        float result = PlanetSearchProfile.flooredProminence(null);
+        assertEquals((float) ProminenceCalculator.FLOOR, result, 1e-9f,
+                "a null prominence must be floored to ProminenceCalculator.FLOOR (0.05)");
+        assertEquals(0.05f, result, 1e-9f, "FLOOR is the documented 0.05 safety floor");
+    }
+
+    @Test
+    public void flooredProminenceIsNeverNull() {
+        // The whole point of the net: the result is a primitive float, never null, so the field
+        // can't be omitted from _source under @JsonInclude(NON_NULL).
+        Float result = PlanetSearchProfile.flooredProminence(null);
+        assertNotNull(result, "floored prominence must never be null");
+        assertFalse(Float.isNaN(result), "floored prominence must never be NaN");
+    }
+
+    @Test
+    public void existingProminenceIsLeftUnchanged() {
+        // The floor must NOT overwrite a real, computed value (it only fills the null gap).
+        assertEquals(0.73f, PlanetSearchProfile.flooredProminence(0.73f), 1e-9f,
+                "a real prominence must pass through unchanged");
+    }
+
+    @Test
+    public void lowButNonNullProminenceIsLeftUnchanged() {
+        // Even a value below the floor is a *real* computed value (ProminenceCalculator already
+        // clamps to >= FLOOR); the insert-path net only fills nulls, it does not re-floor.
+        assertEquals(0.01f, PlanetSearchProfile.flooredProminence(0.01f), 1e-9f,
+                "the insert net only fills nulls; it must not re-floor an existing value");
+    }
+
+    /**
+     * Build-time placement invariant. These ranking-floor computations live in the Java indexer and
+     * are exercised at index/emit time — NOT at query time. Asserting the symbols exist here
+     * (package-private static on {@code PlanetSearchProfile}, alongside {@code ProminenceCalculator.FLOOR})
+     * pins that the guarded logic is in the indexer module.
+     */
+    @Test
+    public void floorLogicLivesInTheIndexerAtBuildTime() throws Exception {
+        var m = PlanetSearchProfile.class.getDeclaredMethod("flooredProminence", Float.class);
+        assertTrue(Modifier.isStatic(m.getModifiers()),
+                "flooredProminence is a build-time static in the Java indexer module");
+        assertEquals(float.class, m.getReturnType());
+        // FLOOR is the indexer-owned constant the insert path floors to.
+        assertEquals(0.05, ProminenceCalculator.FLOOR, 1e-9,
+                "the indexer owns the documented 0.05 prominence floor");
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/InsertProminenceFloorTest.java
+++ b/src/test/java/il/org/osm/israelhiking/InsertProminenceFloorTest.java
@@ -9,22 +9,6 @@ import java.lang.reflect.Modifier;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-/**
- * Guards the INSERT-path prominence safety floor (FR-B6).
- *
- * <p>This is distinct from {@code ProminenceCalculatorTest.prominenceIsNeverZero}, which guards the
- * CALCULATOR floor. Some emit paths (ski-lift ways, relation-completion) never run
- * {@code convertTagsToDocument}, so {@code pointDocument.poiProminence} arrives null at
- * {@code insertPointToElasticsearch}. The insert-path floor must turn that null into
- * {@code (float) ProminenceCalculator.FLOOR} (0.05) so it can't serialize as null —
- * which, given {@code @JsonInclude(NON_NULL)}, would be OMITTED from _source -> field_value_factor
- * {@code missing:1.0} -> the doc unfairly outranks a real, scored feature (poiProminence &lt; 1).
- *
- * <p>The floored logic was extracted to the package-private static {@code flooredProminence(Float)}
- * (a behavior-preserving refactor — no contract/API change) so it can be unit-tested without
- * touching the private {@code insertPointToElasticsearch} / its real {@code BulkIngester}. No mock
- * is needed: the helper is pure.
- */
 @Tag("unit")
 public class InsertProminenceFloorTest {
 
@@ -38,8 +22,6 @@ public class InsertProminenceFloorTest {
 
     @Test
     public void flooredProminenceIsNeverNull() {
-        // The whole point of the net: the result is a primitive float, never null, so the field
-        // can't be omitted from _source under @JsonInclude(NON_NULL).
         Float result = PlanetSearchProfile.flooredProminence(null);
         assertNotNull(result, "floored prominence must never be null");
         assertFalse(Float.isNaN(result), "floored prominence must never be NaN");
@@ -47,33 +29,35 @@ public class InsertProminenceFloorTest {
 
     @Test
     public void existingProminenceIsLeftUnchanged() {
-        // The floor must NOT overwrite a real, computed value (it only fills the null gap).
         assertEquals(0.73f, PlanetSearchProfile.flooredProminence(0.73f), 1e-9f,
                 "a real prominence must pass through unchanged");
     }
 
     @Test
     public void lowButNonNullProminenceIsLeftUnchanged() {
-        // Even a value below the floor is a *real* computed value (ProminenceCalculator already
-        // clamps to >= FLOOR); the insert-path net only fills nulls, it does not re-floor.
         assertEquals(0.01f, PlanetSearchProfile.flooredProminence(0.01f), 1e-9f,
                 "the insert net only fills nulls; it must not re-floor an existing value");
     }
 
-    /**
-     * Build-time placement invariant. These ranking-floor computations live in the Java indexer and
-     * are exercised at index/emit time — NOT at query time. Asserting the symbols exist here
-     * (package-private static on {@code PlanetSearchProfile}, alongside {@code ProminenceCalculator.FLOOR})
-     * pins that the guarded logic is in the indexer module.
-     */
     @Test
     public void floorLogicLivesInTheIndexerAtBuildTime() throws Exception {
         var m = PlanetSearchProfile.class.getDeclaredMethod("flooredProminence", Float.class);
         assertTrue(Modifier.isStatic(m.getModifiers()),
                 "flooredProminence is a build-time static in the Java indexer module");
         assertEquals(float.class, m.getReturnType());
-        // FLOOR is the indexer-owned constant the insert path floors to.
         assertEquals(0.05, ProminenceCalculator.FLOOR, 1e-9,
                 "the indexer owns the documented 0.05 prominence floor");
+    }
+
+    @Test
+    public void unsetProminenceIsNonNullAfterFloor() throws Exception {
+        PointDocument doc = new PointDocument();
+        assertEquals(null, doc.poiProminence, "a doc that skipped setProminence starts null");
+        doc.poiProminence = PlanetSearchProfile.flooredProminence(doc.poiProminence);
+        assertNotNull(doc.poiProminence,
+                "after the insert-path floor the field is non-null, so @JsonInclude(NON_NULL) keeps it");
+        assertEquals((float) ProminenceCalculator.FLOOR, doc.poiProminence, 1e-9f);
+
+        assertEquals(Float.class, PointDocument.class.getField("poiProminence").getType());
     }
 }

--- a/src/test/java/il/org/osm/israelhiking/ParseFirstNumberTest.java
+++ b/src/test/java/il/org/osm/israelhiking/ParseFirstNumberTest.java
@@ -6,10 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-/**
- * Defensive parsing of free-text OSM ele/population values. Must never throw; returns NaN when there
- * is no usable number.
- */
 @Tag("unit")
 public class ParseFirstNumberTest {
 
@@ -55,19 +51,41 @@ public class ParseFirstNumberTest {
 
     @Test
     public void rangeTakesFirstNumber() {
-        // "100-200" -> 100 (the hyphen ends the first number)
         assertEquals(100.0, PlanetSearchProfile.parseFirstNumber("100-200"), 1e-9);
     }
 
     @Test
     public void pureNonNumericIsNaN() {
-        // "abc" has no usable number -> NaN (never throws).
         assertTrue(Double.isNaN(PlanetSearchProfile.parseFirstNumber("abc")));
     }
 
     @Test
     public void commaThousandsWithUnitSuffix() {
-        // "1,234 m" -> 1234.0 (comma stripped as thousands sep, " m" ends the number).
         assertEquals(1234.0, PlanetSearchProfile.parseFirstNumber("1,234 m"), 1e-9);
+    }
+
+    @Test
+    public void negativeInteger() {
+        assertEquals(-430.0, PlanetSearchProfile.parseFirstNumber("-430"), 1e-9);
+    }
+
+    @Test
+    public void negativeWithUnitSuffix() {
+        assertEquals(-430.0, PlanetSearchProfile.parseFirstNumber("-430 m"), 1e-9);
+    }
+
+    @Test
+    public void negativeWithThousandsSeparator() {
+        assertEquals(-1234.0, PlanetSearchProfile.parseFirstNumber("-1,234"), 1e-9);
+    }
+
+    @Test
+    public void rangeSeparatorIsNotASign() {
+        assertEquals(100.0, PlanetSearchProfile.parseFirstNumber("100-200"), 1e-9);
+    }
+
+    @Test
+    public void strayLeadingDashIsNotASign() {
+        assertEquals(430.0, PlanetSearchProfile.parseFirstNumber("- 430"), 1e-9);
     }
 }

--- a/src/test/java/il/org/osm/israelhiking/ParseFirstNumberTest.java
+++ b/src/test/java/il/org/osm/israelhiking/ParseFirstNumberTest.java
@@ -1,0 +1,73 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Defensive parsing of free-text OSM ele/population values. Must never throw; returns NaN when there
+ * is no usable number.
+ */
+@Tag("unit")
+public class ParseFirstNumberTest {
+
+    @Test
+    public void plainInteger() {
+        assertEquals(4302.0, PlanetSearchProfile.parseFirstNumber("4302"), 1e-9);
+    }
+
+    @Test
+    public void decimal() {
+        assertEquals(4302.3, PlanetSearchProfile.parseFirstNumber("4302.3"), 1e-9);
+    }
+
+    @Test
+    public void thousandsSeparatorComma() {
+        assertEquals(14115.0, PlanetSearchProfile.parseFirstNumber("14,115"), 1e-9);
+    }
+
+    @Test
+    public void thousandsSeparatorSpace() {
+        assertEquals(1000.0, PlanetSearchProfile.parseFirstNumber("1 000"), 1e-9);
+    }
+
+    @Test
+    public void numberWithUnitSuffix() {
+        assertEquals(14115.0, PlanetSearchProfile.parseFirstNumber("14115 ft"), 1e-9);
+    }
+
+    @Test
+    public void yesIsNotANumber() {
+        assertTrue(Double.isNaN(PlanetSearchProfile.parseFirstNumber("yes")));
+    }
+
+    @Test
+    public void nullIsNaN() {
+        assertTrue(Double.isNaN(PlanetSearchProfile.parseFirstNumber(null)));
+    }
+
+    @Test
+    public void emptyIsNaN() {
+        assertTrue(Double.isNaN(PlanetSearchProfile.parseFirstNumber("")));
+    }
+
+    @Test
+    public void rangeTakesFirstNumber() {
+        // "100-200" -> 100 (the hyphen ends the first number)
+        assertEquals(100.0, PlanetSearchProfile.parseFirstNumber("100-200"), 1e-9);
+    }
+
+    @Test
+    public void pureNonNumericIsNaN() {
+        // "abc" has no usable number -> NaN (never throws).
+        assertTrue(Double.isNaN(PlanetSearchProfile.parseFirstNumber("abc")));
+    }
+
+    @Test
+    public void commaThousandsWithUnitSuffix() {
+        // "1,234 m" -> 1234.0 (comma stripped as thousands sep, " m" ends the number).
+        assertEquals(1234.0, PlanetSearchProfile.parseFirstNumber("1,234 m"), 1e-9);
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/ProminenceCalculatorTest.java
+++ b/src/test/java/il/org/osm/israelhiking/ProminenceCalculatorTest.java
@@ -1,0 +1,97 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class ProminenceCalculatorTest {
+
+    private static final double NO_ELE = Double.NaN;
+
+    @Test
+    public void famousPeakWithQRankRanksHigh() {
+        // Pikes Peak: a ~4300m peak with a strong QRank signal and an image.
+        var r = ProminenceCalculator.compute("peak", null, null, null, null, null,
+                4302, /*image*/ true, /*website*/ false, /*wikidata*/ true, /*qrank*/ 359_540L);
+        assertTrue(r.prominence > 0.7, "famous high peak should score high, was " + r.prominence);
+        assertTrue(r.eleNorm > 0.9, "4302m should normalize near the top, was " + r.eleNorm);
+        assertTrue(r.qrankNorm > 0.8, "359k QRank should log-normalize high, was " + r.qrankNorm);
+    }
+
+    @Test
+    public void duplicateNodeWithNoSignalScoresLow() {
+        // The duplicate Pikes Peak node: same name, but no class, no ele, no wikidata/qrank.
+        // It gets only the floor + the generic-node baseline (0.05 + 0.45*0.25 = 0.1625) — low,
+        // and far below a real classified/popular feature, which is what breaks the duplicate tie.
+        var r = ProminenceCalculator.compute(null, null, null, null, null, null,
+                NO_ELE, false, false, false, 0L);
+        assertEquals(0.1625f, r.prominence, 1e-4, "a node with no signal should score at the baseline");
+        assertEquals(0f, r.qrankNorm, 1e-6);
+        // Crucially, much lower than a famous peak (validated separately) so the multiply reorders it down.
+        var famous = ProminenceCalculator.compute("peak", null, null, null, null, null,
+                4302, true, false, true, 359_540L);
+        assertTrue(famous.prominence > r.prominence * 3, "famous peak must dominate an unsignalled node");
+    }
+
+    @Test
+    public void prominenceIsNeverZero() {
+        // Floor guarantees a query-time multiply never annihilates a hit.
+        var r = ProminenceCalculator.compute(null, null, null, null, null, null,
+                NO_ELE, false, false, false, 0L);
+        assertTrue(r.prominence >= ProminenceCalculator.FLOOR);
+        assertTrue(r.prominence > 0f);
+    }
+
+    @Test
+    public void cityOutranksVillage() {
+        var city = ProminenceCalculator.compute(null, "city", null, null, null, null,
+                NO_ELE, false, false, false, 0L);
+        var village = ProminenceCalculator.compute(null, "village", null, null, null, null,
+                NO_ELE, false, false, false, 0L);
+        assertTrue(city.prominence > village.prominence,
+                "city " + city.prominence + " should outrank village " + village.prominence);
+    }
+
+    @Test
+    public void higherPeakOutranksLowerPeak() {
+        var high = ProminenceCalculator.compute("peak", null, null, null, null, null,
+                4000, false, false, false, 0L);
+        var low = ProminenceCalculator.compute("peak", null, null, null, null, null,
+                200, false, false, false, 0L);
+        assertTrue(high.prominence > low.prominence,
+                "a 4000m peak should outrank a 200m hill");
+    }
+
+    @Test
+    public void nationalParkScoresAboveGenericNode() {
+        var park = ProminenceCalculator.compute(null, null, "national_park", null, null, null,
+                NO_ELE, false, false, false, 0L);
+        var generic = ProminenceCalculator.compute(null, null, null, null, null, null,
+                NO_ELE, false, false, false, 0L);
+        assertTrue(park.prominence > generic.prominence);
+    }
+
+    @Test
+    public void qrankOnlyCountsWithWikidataPresence() {
+        // qrankRaw>1 contributes regardless, but a 0/1 raw value must not.
+        var withQ = ProminenceCalculator.compute("spring", null, null, null, null, null,
+                NO_ELE, false, false, true, 50_000L);
+        var noQ = ProminenceCalculator.compute("spring", null, null, null, null, null,
+                NO_ELE, false, false, true, 0L);
+        assertTrue(withQ.prominence > noQ.prominence, "a popular spring should beat an obscure one");
+        assertEquals(0f, noQ.qrankNorm, 1e-6);
+    }
+
+    @Test
+    public void outputAlwaysInUnitRange() {
+        // Even maxed-out inputs stay clamped to [0,1].
+        var r = ProminenceCalculator.compute("peak", "city", "national_park", "viewpoint", "ruins",
+                "stream", 8849, true, true, true, Long.MAX_VALUE);
+        assertTrue(r.prominence >= 0f && r.prominence <= 1f, "prominence out of range: " + r.prominence);
+        assertTrue(r.base >= 0f && r.base <= 1f);
+        assertTrue(r.qrankNorm >= 0f && r.qrankNorm <= 1f);
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/ProminenceCalculatorTest.java
+++ b/src/test/java/il/org/osm/israelhiking/ProminenceCalculatorTest.java
@@ -13,9 +13,8 @@ public class ProminenceCalculatorTest {
 
     @Test
     public void famousPeakWithQRankRanksHigh() {
-        // Pikes Peak: a ~4300m peak with a strong QRank signal and an image.
         var r = ProminenceCalculator.compute("peak", null, null, null, null, null,
-                4302, /*image*/ true, /*website*/ false, /*wikidata*/ true, /*qrank*/ 359_540L);
+                4302, true, false, true, 359_540L);
         assertTrue(r.prominence > 0.7, "famous high peak should score high, was " + r.prominence);
         assertTrue(r.eleNorm > 0.9, "4302m should normalize near the top, was " + r.eleNorm);
         assertTrue(r.qrankNorm > 0.8, "359k QRank should log-normalize high, was " + r.qrankNorm);
@@ -23,14 +22,10 @@ public class ProminenceCalculatorTest {
 
     @Test
     public void duplicateNodeWithNoSignalScoresLow() {
-        // The duplicate Pikes Peak node: same name, but no class, no ele, no wikidata/qrank.
-        // It gets only the floor + the generic-node baseline (0.05 + 0.45*0.25 = 0.1625) — low,
-        // and far below a real classified/popular feature, which is what breaks the duplicate tie.
         var r = ProminenceCalculator.compute(null, null, null, null, null, null,
                 NO_ELE, false, false, false, 0L);
         assertEquals(0.1625f, r.prominence, 1e-4, "a node with no signal should score at the baseline");
         assertEquals(0f, r.qrankNorm, 1e-6);
-        // Crucially, much lower than a famous peak (validated separately) so the multiply reorders it down.
         var famous = ProminenceCalculator.compute("peak", null, null, null, null, null,
                 4302, true, false, true, 359_540L);
         assertTrue(famous.prominence > r.prominence * 3, "famous peak must dominate an unsignalled node");
@@ -38,7 +33,6 @@ public class ProminenceCalculatorTest {
 
     @Test
     public void prominenceIsNeverZero() {
-        // Floor guarantees a query-time multiply never annihilates a hit.
         var r = ProminenceCalculator.compute(null, null, null, null, null, null,
                 NO_ELE, false, false, false, 0L);
         assertTrue(r.prominence >= ProminenceCalculator.FLOOR);
@@ -76,7 +70,6 @@ public class ProminenceCalculatorTest {
 
     @Test
     public void qrankOnlyCountsWithWikidataPresence() {
-        // qrankRaw>1 contributes regardless, but a 0/1 raw value must not.
         var withQ = ProminenceCalculator.compute("spring", null, null, null, null, null,
                 NO_ELE, false, false, true, 50_000L);
         var noQ = ProminenceCalculator.compute("spring", null, null, null, null, null,
@@ -86,8 +79,26 @@ public class ProminenceCalculatorTest {
     }
 
     @Test
+    public void qrankIgnoredWhenWikidataAbsent() {
+        var r = ProminenceCalculator.compute("spring", null, null, null, null, null,
+                NO_ELE, false, false, false, 1_000_000L);
+        assertEquals(0f, r.qrankNorm, 1e-6, "qnorm must be 0 when wikidata is absent");
+    }
+
+    @Test
+    public void belowSeaLevelPeakIsFlooredToZeroElevation() {
+        var below = ProminenceCalculator.compute("peak", null, null, null, null, null,
+                -430, false, false, false, 0L);
+        assertEquals(0f, below.eleNorm, 1e-6, "a below-sea-level feature must floor to eleNorm 0");
+        assertEquals(0.30f, below.base, 1e-4, "a -430m peak must not get an elevation boost");
+        var atSeaLevel = ProminenceCalculator.compute("peak", null, null, null, null, null,
+                0, false, false, false, 0L);
+        assertEquals(atSeaLevel.base, below.base, 1e-6,
+                "a -430m peak must score the same base as a 0m peak, not a +430m one");
+    }
+
+    @Test
     public void outputAlwaysInUnitRange() {
-        // Even maxed-out inputs stay clamped to [0,1].
         var r = ProminenceCalculator.compute("peak", "city", "national_park", "viewpoint", "ruins",
                 "stream", 8849, true, true, true, Long.MAX_VALUE);
         assertTrue(r.prominence >= 0f && r.prominence <= 1f, "prominence out of range: " + r.prominence);

--- a/src/test/java/il/org/osm/israelhiking/QRankIndexTest.java
+++ b/src/test/java/il/org/osm/israelhiking/QRankIndexTest.java
@@ -1,0 +1,69 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.GZIPOutputStream;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("unit")
+public class QRankIndexTest {
+
+    @Test
+    public void emptyIndexReturnsZero() {
+        var idx = QRankIndex.empty();
+        assertEquals(0, idx.getByWikidata("Q665321"));
+        assertEquals(0, idx.size());
+    }
+
+    @Test
+    public void nullPathYieldsEmptyIndexNoException() {
+        var idx = QRankIndex.load(null);
+        assertEquals(0, idx.size());
+        assertEquals(0, idx.getByWikidata("Q42"));
+    }
+
+    @Test
+    public void missingFileYieldsEmptyIndex(@TempDir Path dir) {
+        var idx = QRankIndex.load(dir.resolve("does-not-exist.csv.gz"));
+        assertEquals(0, idx.size());
+    }
+
+    @Test
+    public void parsesGzippedCsvAndLooksUpByWikidata(@TempDir Path dir) throws IOException {
+        Path gz = dir.resolve("qrank.csv.gz");
+        try (OutputStream os = Files.newOutputStream(gz);
+                GZIPOutputStream gzos = new GZIPOutputStream(os)) {
+            gzos.write("Entity,QRank\nQ665321,359540\nQ121211166,34\nQ42,1000000\n"
+                    .getBytes(StandardCharsets.UTF_8));
+        }
+        var idx = QRankIndex.load(gz);
+        assertEquals(3, idx.size());
+        assertEquals(359540, idx.getByWikidata("Q665321"));
+        assertEquals(34, idx.getByWikidata("Q121211166"));
+        assertEquals(1000000, idx.getByWikidata("Q42"));
+    }
+
+    @Test
+    public void unknownOrMalformedWikidataReturnsZero(@TempDir Path dir) throws IOException {
+        Path gz = dir.resolve("qrank.csv.gz");
+        try (OutputStream os = Files.newOutputStream(gz);
+                GZIPOutputStream gzos = new GZIPOutputStream(os)) {
+            gzos.write("Entity,QRank\nQ1,5\n".getBytes(StandardCharsets.UTF_8));
+        }
+        var idx = QRankIndex.load(gz);
+        assertEquals(0, idx.getByWikidata("Q999"), "unknown id -> 0");
+        assertEquals(0, idx.getByWikidata(null), "null -> 0");
+        assertEquals(0, idx.getByWikidata(""), "empty -> 0");
+        assertEquals(0, idx.getByWikidata("notaqid"), "malformed -> 0");
+        assertTrue(idx.getByWikidata("Q1") > 0);
+    }
+}


### PR DESCRIPTION
> **Stacked on #79.** The indexer-resilience / lossless-reindex half of the original PR moved to
> #79 (review that first). The 3 resilience commits still show in this PR's diff until #79 merges;
> once it does, this branch is rebased onto `main` to drop them, leaving only the 5 ranking-signal
> commits below.

## What & why

The **index-side companion** for the query-side relevance work in **IsraelHikingMap/Site#2543**.
That PR ranks search results with a `function_score` that reads a build-time **`poiProminence`**
field; this PR is what actually **computes and populates** that field (plus `population`).

Builds on the renamed ranking-signal scheme already merged in `#75` (`poiProminence`,
`poiFeatureClass`, `population`, `poiAreaNormalized`, `intermittent`): `#75` declared the fields,
this PR fills in the prominence/QRank computation and the ES mapping for `poiProminence`. The
indexer-resilience guarantees this work relies on (lossless reindex) are in **#79**.

## What's in it

**Build-time prominence (`poiProminence`)** — `ProminenceCalculator`:

```
prom = clamp01(0.05 + 0.45*base + 0.40*qnorm + 0.10*meta)   // floor 0.05
```
- `base` from `natural`/`place`/`boundary`/`tourism`/`historic`/`waterway` + normalized elevation
  (peaks scale with height; city/town/village tiers; parks; viewpoints; springs; …).
- `qnorm` from the QRank signal, gated on `wikidata` (`log(qrank)/log(3e6)`).
- `meta` from `image` / `website` / `wikidata` presence.
- **Insert-path floor** so every emitted doc carries a `poiProminence > 0` — a query-time
  `field_value_factor` multiply can never zero a result out.

**QRank signal** — `QRankIndex` + new `--qrank-path` arg (documented in the README). Optional:
when no file is passed it runs with an **empty index** (lookups return 0), so the build never
depends on the QRank file being present.

**`population`** — populated for place/admin features.

## Tests

4 new `@Tag("unit")` classes specific to this PR, all green in the default Surefire group (zero
network): `ProminenceCalculatorTest`, `QRankIndexTest`, `ParseFirstNumberTest`,
`InsertProminenceFloorTest`. (The BulkIngester accounting tests live in #79.) Full suite:
**54 tests, 0 failures**.

## Non-breaking

- `poiProminence` is `@JsonInclude(NON_NULL)` and floored on the insert path; the query side
  treats a missing value as `1.0`, so old docs degrade gracefully until the next reindex.
- ES mapping is additive: `poiProminence` searchable; raw components stored `index:false` so
  weights can be re-tuned without a reindex.
- The new fields do nothing until both a reindex runs **and** the query side (#2543) is deployed.

## Merge order

1. **#79** (lossless reindex) — independent indexer hardening; safe on today's index, merge first.
2. Query-side **Site#2543** — reversible binary redeploy, safe on today's index.
3. **This PR** — rebased onto a `main` that already has #79; the multi-hour reindex whose fields
   light up once #2543 is live.

## Follow-up (not in this PR)

- `country_code` — read by #2543's scoring but not yet produced here; separate enrichment.

---

> Draft — companion to IsraelHikingMap/Site#2543.
