### PR TITLE
Index-time prominence + QRank ranking signal (poiProminence) + population

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Additional arguments to this wrapper besides the Planetiler's arguments:
 | `es-bbox-index-alias` | The alias of the index to insert bounding boxes into, it will create "1" and "2" suffix for the relevant index before switching | `bbox` |
 | `external-file-path` | External geojson file path to allow adding non OSM features to the search and POIs. these features should have a specific format | "empty" |
 | `skip-tiles` | Collapse the tile pyramid to z0 so the `.pmtiles` archive is a near-instant stub, to speed up an Elasticsearch-only reindex. The search index is built identically; only the map tiles degrade, so do not use it for a build whose map tiles are consumed. | `false` |
+| `qrank-path` | Path to a gzipped `qrank.csv.gz` used to compute the `poiProminence` ranking signal. Optional — leave empty to build without it (every point still gets a base+metadata prominence; only the QRank signal is omitted). | "empty" |
+
+The QRank data file comes from [https://qrank.toolforge.org](https://qrank.toolforge.org) (CC0): a gzipped CSV (`Entity,QRank`) ranking Wikidata entities by aggregated Wikimedia pageviews. `qrank-path` is optional and fully omittable — omit it and the build runs unchanged without the ~363 MB file.
 
 To run using docker (While having a local elasticsearch running at 9200):
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.univocity</groupId>
+      <artifactId>univocity-parsers</artifactId>
+      <version>2.9.1</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>5.13.4</version>

--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -29,7 +29,8 @@ public class ElasticsearchHelper {
       String bboxIndexAlias,
       String pointsIndexTarget,
       String bboxIndexTarget,
-      String[] supportedLanguages) {
+      String[] supportedLanguages,
+      QRankLookup qrankLookup) {
   }
 
   /**
@@ -218,12 +219,13 @@ public class ElasticsearchHelper {
   public static ElasticRunContext initRun(ElasticsearchClient esClient,
       String pointsIndexAlias,
       String bboxIndexAlias,
-      String[] supportedLanguages) throws Exception {
+      String[] supportedLanguages,
+      QRankLookup qrankLookup) throws Exception {
     var targetPointsIndex = ElasticsearchHelper.createPointsIndex(esClient, pointsIndexAlias,
         supportedLanguages);
     var targetBBoxIndex = ElasticsearchHelper.createBBoxIndex(esClient, bboxIndexAlias, supportedLanguages);
     return new ElasticRunContext(esClient, pointsIndexAlias, bboxIndexAlias, targetPointsIndex, targetBBoxIndex,
-        supportedLanguages);
+        supportedLanguages, qrankLookup);
   }
 
   public static void finalizeRun(ElasticRunContext context) throws Exception {

--- a/src/main/java/il/org/osm/israelhiking/MainClass.java
+++ b/src/main/java/il/org/osm/israelhiking/MainClass.java
@@ -51,8 +51,11 @@ public class MainClass {
                     "bbox");
             var supportedLanguages = args.getString("languages", "Languages to support", "en,he,ru,ar,es").split(",");
             var externalFilePath = args.getString("external-file-path", "External file path", "");
+            var qrankPath = args.getString("qrank-path",
+                    "Path to qrank.csv.gz for the prominence signal (empty = run without it)", "");
+            var qrankLookup = QRankLookup.load(qrankPath.isBlank() ? null : Path.of(qrankPath));
             var context = ElasticsearchHelper.initRun(esClient, pointsIndexAlias, bboxIndexAlias,
-                    supportedLanguages);
+                    supportedLanguages, qrankLookup);
             var profile = new PlanetSearchProfile(planetiler.config(), context);
 
             String area = args.getString("area", "geofabrik area to download", "israel-and-palestine");

--- a/src/main/java/il/org/osm/israelhiking/OsmFeatureClassifier.java
+++ b/src/main/java/il/org/osm/israelhiking/OsmFeatureClassifier.java
@@ -1,0 +1,276 @@
+package il.org.osm.israelhiking;
+
+import com.onthegomap.planetiler.reader.WithTags;
+
+final class OsmFeatureClassifier {
+
+  static final double DEFAULT_BASE_SCORE = 0.25;
+
+  enum Category {
+    NATURE_RESERVE("icon-leaf", "#008000", "Other", 0.80, 0.0),
+    PROTECTED_NODE("icon-leaf", "#008000", "Other", DEFAULT_BASE_SCORE, 0.0),
+    ROUTE_HIKING("icon-hike", "black", "Hiking", DEFAULT_BASE_SCORE, 0.0),
+    ROUTE_BICYCLE("icon-bike", "black", "Bicycle", DEFAULT_BASE_SCORE, 0.0),
+    ROUTE_4X4("icon-four-by-four", "black", "4x4", DEFAULT_BASE_SCORE, 0.0),
+    HISTORIC_RUINS("icon-ruins", "#666666", "Historic", 0.55, 0.0),
+    HISTORIC_ARCHAEOLOGICAL("icon-archaeological", "#666666", "Historic", 0.55, 0.0),
+    HISTORIC_MEMORIAL("icon-memorial", "#666666", "Historic", 0.55, 0.0),
+    HISTORIC_TOMB("icon-cave", "black", "Natural", 0.55, 0.0),
+    PICNIC("icon-picnic", "#734a08", "Camping", DEFAULT_BASE_SCORE, 0.0),
+    NATURAL_CAVE("icon-cave", "black", "Natural", 0.30, 0.0),
+    NATURAL_SPRING("icon-tint", "#1e80e3", "Water", 0.30, 0.0),
+    NATURAL_TREE("icon-tree", "#008000", "Natural", DEFAULT_BASE_SCORE, 0.0),
+    NATURAL_FLOWERS("icon-flowers", "#008000", "Natural", DEFAULT_BASE_SCORE, 0.0),
+    NATURAL_WATERHOLE("icon-waterhole", "#1e80e3", "Water", DEFAULT_BASE_SCORE, 0.0),
+    PEAK("icon-peak", "black", "Natural", 0.30, 0.55),
+    RIDGE("icon-peak", "black", "Natural", DEFAULT_BASE_SCORE, 0.0),
+    WATER_BODY("icon-tint", "#1e80e3", "Water", DEFAULT_BASE_SCORE, 0.0),
+    MAN_MADE_WATER_WELL("icon-water-well", "#1e80e3", "Water", DEFAULT_BASE_SCORE, 0.0),
+    MAN_MADE_CISTERN("icon-cistern", "#1e80e3", "Water", DEFAULT_BASE_SCORE, 0.0),
+    WATERFALL("icon-waterfall", "#1e80e3", "Water", 0.30, 0.0),
+    WATERWAY_RELATION("icon-river", "#1e80e3", "Water", DEFAULT_BASE_SCORE, 0.0),
+    PLACE_CITY("icon-home", "black", "Wikipedia", 1.00, 0.0),
+    PLACE_TOWN("icon-home", "black", "Wikipedia", 0.80, 0.0),
+    PLACE_VILLAGE("icon-home", "black", "Wikipedia", 0.55, 0.0),
+    PLACE_HAMLET("icon-home", "black", "Wikipedia", 0.35, 0.0),
+    PLACE_OTHER("icon-home", "black", "Wikipedia", 0.45, 0.0),
+    PLACE_BLANK("icon-home", "black", "Wikipedia", DEFAULT_BASE_SCORE, 0.0),
+    VIEWPOINT("icon-viewpoint", "#008000", "Viewpoint", 0.55, 0.0),
+    CAMP_SITE("icon-campsite", "#734a08", "Camping", DEFAULT_BASE_SCORE, 0.0),
+    ATTRACTION("icon-star", "#ffb800", "Other", 0.55, 0.0),
+    ARTWORK("icon-artwork", "#ffb800", "Other", DEFAULT_BASE_SCORE, 0.0),
+    ALPINE_HUT("icon-alpinehut", "#734a08", "Camping", 0.55, 0.0),
+    HIGHWAY_CYCLEWAY("icon-bike", "black", "Bicycle", DEFAULT_BASE_SCORE, 0.0),
+    HIGHWAY_FOOT("icon-hike", "black", "Hiking", DEFAULT_BASE_SCORE, 0.0),
+    HIGHWAY_TRACK("icon-four-by-four", "black", "4x4", DEFAULT_BASE_SCORE, 0.0),
+    WORSHIP_JEWISH("icon-synagogue", "black", "Other", DEFAULT_BASE_SCORE, 0.0),
+    WORSHIP_CHRISTIAN("icon-church", "black", "Other", DEFAULT_BASE_SCORE, 0.0),
+    WORSHIP_MUSLIM("icon-mosque", "black", "Other", DEFAULT_BASE_SCORE, 0.0),
+    WORSHIP_OTHER("icon-holy-place", "black", "Other", DEFAULT_BASE_SCORE, 0.0),
+    INATURE("icon-inature", "#116C00", "iNature", DEFAULT_BASE_SCORE, 0.0),
+    FALLBACK_HISTORIC("icon-search", "black", "Other", 0.55, 0.0),
+    FALLBACK_WATER("icon-search", "black", "Other", 0.30, 0.0),
+    FALLBACK("icon-search", "black", "Other", DEFAULT_BASE_SCORE, 0.0),
+
+    NONICON_GENERIC("icon-search", "black", "Other", DEFAULT_BASE_SCORE, 0.0),
+    NONICON_STATION("icon-bus-stop", "black", "Other", DEFAULT_BASE_SCORE, 0.0),
+    NONICON_RIDGE("icon-peak", "black", "Other", DEFAULT_BASE_SCORE, 0.0),
+    NONICON_MTB("icon-bike", "green", "Bicycle", DEFAULT_BASE_SCORE, 0.0),
+    NONICON_FOREST("icon-tree", "#008000", "Other", DEFAULT_BASE_SCORE, 0.0),
+    NONICON_WIKIPEDIA("icon-wikipedia-w", "black", "Wikipedia", DEFAULT_BASE_SCORE, 0.0);
+
+    final String icon;
+    final String color;
+    final String poiCategory;
+    final double baseScore;
+    final double elevationWeight;
+
+    Category(String icon, String color, String poiCategory, double baseScore, double elevationWeight) {
+      this.icon = icon;
+      this.color = color;
+      this.poiCategory = poiCategory;
+      this.baseScore = baseScore;
+      this.elevationWeight = elevationWeight;
+    }
+  }
+
+  private OsmFeatureClassifier() {}
+
+  static Category classify(WithTags f) {
+    String boundary = f.getString("boundary");
+    if ("protected_area".equals(boundary) || "national_park".equals(boundary)) {
+      return Category.NATURE_RESERVE;
+    }
+    if ("nature_reserve".equals(f.getString("leisure"))) {
+      return Category.PROTECTED_NODE;
+    }
+
+    String route = f.getString("route");
+    if (route != null) {
+      switch (route) {
+        case "hiking":
+        case "foot":
+          return Category.ROUTE_HIKING;
+        case "bicycle":
+        case "mtb":
+          return Category.ROUTE_BICYCLE;
+        case "road":
+          if ("yes".equals(f.getString("scenic"))) {
+            return Category.ROUTE_4X4;
+          }
+      }
+    }
+
+    String historic = f.getString("historic");
+    if (historic != null) {
+      switch (historic) {
+        case "ruins":
+          return Category.HISTORIC_RUINS;
+        case "archaeological_site":
+          return Category.HISTORIC_ARCHAEOLOGICAL;
+        case "memorial":
+        case "monument":
+          return Category.HISTORIC_MEMORIAL;
+        case "tomb":
+          return Category.HISTORIC_TOMB;
+      }
+    }
+
+    if ("picnic_table".equals(f.getString("leisure"))
+        || "picnic_site".equals(f.getString("tourism"))
+        || "picnic".equals(f.getString("amenity"))) {
+      return Category.PICNIC;
+    }
+
+    String natural = f.getString("natural");
+    if (natural != null) {
+      switch (natural) {
+        case "cave_entrance":
+          return Category.NATURAL_CAVE;
+        case "spring":
+          return Category.NATURAL_SPRING;
+        case "tree":
+          return Category.NATURAL_TREE;
+        case "flowers":
+          return Category.NATURAL_FLOWERS;
+        case "waterhole":
+          return Category.NATURAL_WATERHOLE;
+        case "peak":
+        case "volcano":
+          return Category.PEAK;
+        case "ridge":
+          return Category.RIDGE;
+      }
+    }
+
+    String water = f.getString("water");
+    if ("reservoir".equals(water) || "pond".equals(water) || "lake".equals(water)
+        || "stream_pool".equals(water)) {
+      return Category.WATER_BODY;
+    }
+
+    String manMade = f.getString("man_made");
+    if (manMade != null) {
+      switch (manMade) {
+        case "water_well":
+          return Category.MAN_MADE_WATER_WELL;
+        case "cistern":
+          return Category.MAN_MADE_CISTERN;
+      }
+    }
+
+    String waterway = f.getString("waterway");
+    if ("waterfall".equals(waterway)) {
+      return Category.WATERFALL;
+    }
+
+    if ("waterway".equals(f.getString("type"))) {
+      return Category.WATERWAY_RELATION;
+    }
+
+    String place = f.getString("place");
+    if (place != null) {
+      if (place.isBlank()) {
+        return Category.PLACE_BLANK;
+      }
+      switch (place) {
+        case "city":
+          return Category.PLACE_CITY;
+        case "town":
+          return Category.PLACE_TOWN;
+        case "village":
+          return Category.PLACE_VILLAGE;
+        case "hamlet":
+          return Category.PLACE_HAMLET;
+        default:
+          return Category.PLACE_OTHER;
+      }
+    }
+
+    String tourism = f.getString("tourism");
+    if (tourism != null) {
+      switch (tourism) {
+        case "viewpoint":
+          return Category.VIEWPOINT;
+        case "camp_site":
+          return Category.CAMP_SITE;
+        case "attraction":
+          return Category.ATTRACTION;
+        case "artwork":
+          return Category.ARTWORK;
+        case "alpine_hut":
+          return Category.ALPINE_HUT;
+      }
+    }
+
+    String highway = f.getString("highway");
+    if (highway != null) {
+      switch (highway) {
+        case "cycleway":
+          return Category.HIGHWAY_CYCLEWAY;
+        case "footway":
+        case "path":
+          return Category.HIGHWAY_FOOT;
+        case "track":
+          return Category.HIGHWAY_TRACK;
+      }
+    }
+
+    String amenity = f.getString("amenity");
+    if ("place_of_worship".equals(amenity) || "monastery".equals(amenity)) {
+      String religion = f.getString("religion") != null ? f.getString("religion") : "";
+      switch (religion) {
+        case "jewish":
+          return Category.WORSHIP_JEWISH;
+        case "christian":
+          return Category.WORSHIP_CHRISTIAN;
+        case "muslim":
+          return Category.WORSHIP_MUSLIM;
+        default:
+          return Category.WORSHIP_OTHER;
+      }
+    }
+
+    if (f.getString("ref:IL:inature") != null) {
+      return Category.INATURE;
+    }
+
+    if (historic != null) {
+      return Category.FALLBACK_HISTORIC;
+    }
+    if ("hot_spring".equals(natural) || waterway != null) {
+      return Category.FALLBACK_WATER;
+    }
+    return Category.FALLBACK;
+  }
+
+  static Category classifyNonIcon(WithTags f) {
+    Category c = null;
+    if (f.hasTag("amenity", "place_of_worship") || f.hasTag("natural", "valley")) {
+      c = Category.NONICON_GENERIC;
+    }
+    if (f.hasTag("building") && !f.hasTag("building", "no", "none", "No")) {
+      c = Category.NONICON_GENERIC;
+    }
+    if (f.hasTag("railway", "station") || f.hasTag("aerialway", "station")) {
+      c = Category.NONICON_STATION;
+    }
+    if (f.hasTag("natural", "ridge")) {
+      c = Category.NONICON_RIDGE;
+    }
+    if (f.hasTag("landuse", "recreation_ground") && f.hasTag("sport", "mtb")) {
+      c = Category.NONICON_MTB;
+    }
+    if (f.hasTag("landuse", "forest")) {
+      c = Category.NONICON_FOREST;
+    }
+    if (c == null) {
+      return null;
+    }
+    if (c == Category.NONICON_GENERIC
+        && (f.getString("wikidata") != null || f.getString("wikipedia") != null)) {
+      return Category.NONICON_WIKIPEDIA;
+    }
+    return c;
+  }
+}

--- a/src/main/java/il/org/osm/israelhiking/OsmNumberParser.java
+++ b/src/main/java/il/org/osm/israelhiking/OsmNumberParser.java
@@ -1,0 +1,63 @@
+package il.org.osm.israelhiking;
+
+import java.util.Locale;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class OsmNumberParser {
+
+  private static final Pattern FIRST_NUMBER = Pattern.compile("-?\\d[\\d ,']*(?:\\.\\d+)?");
+  private static final Pattern POPULATION_DIGITS = Pattern.compile("-?\\d[\\d ,.']*");
+  private static final double FEET_TO_METERS = 0.3048;
+
+  private OsmNumberParser() {}
+
+  static OptionalInt parsePopulation(String raw) {
+    if (raw == null) {
+      return OptionalInt.empty();
+    }
+    Matcher matcher = POPULATION_DIGITS.matcher(raw);
+    if (!matcher.find()) {
+      return OptionalInt.empty();
+    }
+    try {
+      long value = Long.parseLong(matcher.group().replaceAll("[ ,.']", ""));
+      if (value <= 0) {
+        return OptionalInt.empty();
+      }
+      return OptionalInt.of((int) Math.min(value, Integer.MAX_VALUE));
+    } catch (NumberFormatException e) {
+      return OptionalInt.empty();
+    }
+  }
+
+  static OptionalDouble parseElevation(String raw) {
+    double n = firstNumber(raw);
+    if (Double.isNaN(n)) {
+      return OptionalDouble.empty();
+    }
+    return OptionalDouble.of(isFeet(raw) ? n * FEET_TO_METERS : n);
+  }
+
+  private static boolean isFeet(String raw) {
+    String t = raw.toLowerCase(Locale.ROOT).trim();
+    return t.endsWith("ft") || t.endsWith("feet") || t.endsWith("foot") || t.endsWith("'");
+  }
+
+  private static double firstNumber(String raw) {
+    if (raw == null) {
+      return Double.NaN;
+    }
+    Matcher matcher = FIRST_NUMBER.matcher(raw);
+    if (!matcher.find()) {
+      return Double.NaN;
+    }
+    try {
+      return Double.parseDouble(matcher.group().replaceAll("[ ,']", ""));
+    } catch (NumberFormatException e) {
+      return Double.NaN;
+    }
+  }
+}

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -98,6 +98,38 @@ public class PlanetSearchProfile implements Profile {
     if (feature.hasTag("intermittent", "yes")) {
       pointDocument.intermittent = true;
     }
+    setProminence(pointDocument, feature);
+    setPopulation(pointDocument, feature);
+  }
+
+  private void setPopulation(PointDocument pointDocument, WithTags feature) {
+    String place = feature.getString("place");
+    if (place == null || place.isBlank()) {
+      return;
+    }
+    var parsed = OsmNumberParser.parsePopulation(feature.getString("population"));
+    if (parsed.isPresent()) {
+      pointDocument.population = parsed.getAsInt();
+      return;
+    }
+    switch (place) {
+      case "city":    pointDocument.population = 1_000_000; break;
+      case "town":    pointDocument.population = 50_000; break;
+      case "village": pointDocument.population = 2_000; break;
+      case "hamlet":  pointDocument.population = 200; break;
+      default:        pointDocument.population = 20; break;
+    }
+  }
+
+  private void setProminence(PointDocument pointDocument, WithTags feature) {
+    long qrankRaw = this.context.qrankLookup().qrankFor(pointDocument.wikidata);
+    double ele = OsmNumberParser.parseElevation(feature.getString("ele")).orElse(Double.NaN);
+    boolean hasImage = pointDocument.image != null || pointDocument.wikimedia_commons != null;
+    boolean hasWebsite = pointDocument.website != null;
+    boolean hasWikidata = pointDocument.wikidata != null;
+
+    pointDocument.poiProminence = ProminenceCalculator.compute(
+        OsmFeatureClassifier.classify(feature), ele, hasImage, hasWebsite, hasWikidata, qrankRaw);
   }
 
   private void setDifficulty(PointDocument pointDocument, WithTags feature) {
@@ -575,63 +607,15 @@ public class PlanetSearchProfile implements Profile {
     if (!feature.hasTag("name")) {
       return;
     }
-    var pointDocument = new PointDocument();
-    if (feature.hasTag("amenity", "place_of_worship") ||
-        feature.hasTag("natural", "valley")) {
-      pointDocument.poiIcon = "icon-search";
-      pointDocument.poiIconColor = "black";
-      pointDocument.poiCategory = "Other";
-    }
-    if (feature.hasTag("building") && !feature.hasTag("building", "no", "none", "No")) {
-      pointDocument.poiIcon = "icon-search";
-      pointDocument.poiIconColor = "black";
-      pointDocument.poiCategory = "Other";
-    }
-    if (feature.hasTag("railway", "station") ||
-        feature.hasTag("aerialway", "station")) {
-      pointDocument.poiIcon = "icon-bus-stop";
-      pointDocument.poiIconColor = "black";
-      pointDocument.poiCategory = "Other";
-    }
-    if (feature.hasTag("natural", "ridge")) {
-      pointDocument.poiIcon = "icon-peak";
-      pointDocument.poiIconColor = "black";
-      pointDocument.poiCategory = "Other";
-    }
-    if ((feature.hasTag("landuse", "recreation_ground") && feature.hasTag("sport", "mtb"))) {
-      pointDocument.poiIcon = "icon-bike";
-      pointDocument.poiIconColor = "green";
-      pointDocument.poiCategory = "Bicycle";
-    }
-    if (feature.hasTag("landuse", "forest")) {
-      pointDocument.poiIcon = "icon-tree";
-      pointDocument.poiIconColor = "#008000";
-      pointDocument.poiCategory = "Other";
-    }
-
-    if (pointDocument.poiIcon == null) {
+    var category = OsmFeatureClassifier.classifyNonIcon(feature);
+    if (category == null) {
       return;
     }
-
-    if (pointDocument.poiIcon == "icon-search"
-        && ((feature.getString("wikidata") != null || feature.getString("wikipedia") != null))) {
-      pointDocument.poiIconColor = "black";
-      pointDocument.poiIcon = "icon-wikipedia-w";
-      pointDocument.poiCategory = "Wikipedia";
-    }
-    for (String language : this.context.supportedLanguages()) {
-      CoalesceIntoMap(pointDocument.name, language, feature.getString("name:" + language));
-      CoalesceIntoMap(pointDocument.description, language, feature.getString("description:" + language));
-    }
-    if (feature.hasTag("name")) {
-      CoalesceIntoMap(pointDocument.name, "default", feature.getString("name"));
-    }
-    if (feature.hasTag("description")) {
-      CoalesceIntoMap(pointDocument.description, "default", feature.getString("description"));
-    }
-    pointDocument.wikidata = feature.getString("wikidata");
-    pointDocument.image = feature.getString("image");
-    pointDocument.wikimedia_commons = feature.getString("wikimedia_commons");
+    var pointDocument = new PointDocument();
+    pointDocument.poiIcon = category.icon;
+    pointDocument.poiIconColor = category.color;
+    pointDocument.poiCategory = category.poiCategory;
+    convertTagsToDocument(pointDocument, feature);
     pointDocument.poiSource = "OSM";
     var docId = sourceFeatureToDocumentId(feature);
     var point = feature.canBePolygon() ? (Point) feature.centroidIfConvex()
@@ -833,233 +817,10 @@ public class PlanetSearchProfile implements Profile {
   }
 
   private void setIconColorCategory(PointDocument pointDocument, WithTags feature) {
-    if ("protected_area".equals(feature.getString("boundary")) ||
-        "national_park".equals(feature.getString("boundary")) ||
-        "nature_reserve".equals(feature.getString("leisure"))) {
-      pointDocument.poiIconColor = "#008000";
-      pointDocument.poiIcon = "icon-leaf";
-      pointDocument.poiCategory = "Other";
-      return;
-    }
-    if (feature.getString("route") != null) {
-      switch (feature.getString("route")) {
-        case "hiking":
-        case "foot":
-          pointDocument.poiIconColor = "black";
-          pointDocument.poiIcon = "icon-hike";
-          pointDocument.poiCategory = "Hiking";
-          return;
-        case "bicycle":
-        case "mtb":
-          pointDocument.poiIconColor = "black";
-          pointDocument.poiIcon = "icon-bike";
-          pointDocument.poiCategory = "Bicycle";
-          return;
-        case "road":
-          if ("yes".equals(feature.getString("scenic"))) {
-            pointDocument.poiIconColor = "black";
-            pointDocument.poiCategory = "4x4";
-            pointDocument.poiIcon = "icon-four-by-four";
-            return;
-          }
-      }
-    }
-    if (feature.getString("historic") != null) {
-      pointDocument.poiIconColor = "#666666";
-      pointDocument.poiCategory = "Historic";
-      switch (feature.getString("historic")) {
-        case "ruins":
-          pointDocument.poiIcon = "icon-ruins";
-          return;
-        case "archaeological_site":
-          pointDocument.poiIcon = "icon-archaeological";
-          return;
-        case "memorial":
-        case "monument":
-          pointDocument.poiIcon = "icon-memorial";
-          return;
-        case "tomb":
-          pointDocument.poiIconColor = "black";
-          pointDocument.poiIcon = "icon-cave";
-          pointDocument.poiCategory = "Natural";
-          return;
-      }
-    }
-    if ("picnic_table".equals(feature.getString("leisure")) ||
-        "picnic_site".equals(feature.getString("tourism")) ||
-        "picnic".equals(feature.getString("amenity"))) {
-      pointDocument.poiIconColor = "#734a08";
-      pointDocument.poiIcon = "icon-picnic";
-      pointDocument.poiCategory = "Camping";
-      return;
-    }
-
-    if (feature.getString("natural") != null) {
-      switch (feature.getString("natural")) {
-        case "cave_entrance":
-          pointDocument.poiIconColor = "black";
-          pointDocument.poiIcon = "icon-cave";
-          pointDocument.poiCategory = "Natural";
-          return;
-        case "spring":
-          pointDocument.poiIconColor = "#1e80e3";
-          pointDocument.poiIcon = "icon-tint";
-          pointDocument.poiCategory = "Water";
-          return;
-        case "tree":
-          pointDocument.poiIconColor = "#008000";
-          pointDocument.poiIcon = "icon-tree";
-          pointDocument.poiCategory = "Natural";
-          return;
-        case "flowers":
-          pointDocument.poiIconColor = "#008000";
-          pointDocument.poiIcon = "icon-flowers";
-          pointDocument.poiCategory = "Natural";
-          return;
-        case "waterhole":
-          pointDocument.poiIconColor = "#1e80e3";
-          pointDocument.poiIcon = "icon-waterhole";
-          pointDocument.poiCategory = "Water";
-          return;
-        case "peak":
-        case "volcano":
-        case "ridge":
-          pointDocument.poiIconColor = "black";
-          pointDocument.poiIcon = "icon-peak";
-          pointDocument.poiCategory = "Natural";
-          return;
-      }
-    }
-
-    if ("reservoir".equals(feature.getString("water")) ||
-        "pond".equals(feature.getString("water")) ||
-        "lake".equals(feature.getString("water")) ||
-        "stream_pool".equals(feature.getString("water"))) {
-      pointDocument.poiIconColor = "#1e80e3";
-      pointDocument.poiIcon = "icon-tint";
-      pointDocument.poiCategory = "Water";
-      return;
-    }
-
-    if (feature.getString("man_made") != null) {
-      pointDocument.poiIconColor = "#1e80e3";
-      pointDocument.poiCategory = "Water";
-      switch (feature.getString("man_made")) {
-        case "water_well":
-          pointDocument.poiIcon = "icon-water-well";
-          return;
-        case "cistern":
-          pointDocument.poiIcon = "icon-cistern";
-          return;
-      }
-    }
-
-    if ("waterfall".equals(feature.getString("waterway"))) {
-      pointDocument.poiIconColor = "#1e80e3";
-      pointDocument.poiIcon = "icon-waterfall";
-      pointDocument.poiCategory = "Water";
-      return;
-    }
-
-    if ("waterway".equals(feature.getString("type"))) {
-      pointDocument.poiIconColor = "#1e80e3";
-      pointDocument.poiIcon = "icon-river";
-      pointDocument.poiCategory = "Water";
-      return;
-    }
-
-    if (feature.getString("place") != null) {
-      pointDocument.poiIconColor = "black";
-      pointDocument.poiIcon = "icon-home";
-      pointDocument.poiCategory = "Wikipedia";
-      return;
-    }
-
-    if (feature.getString("tourism") != null) {
-      switch (feature.getString("tourism")) {
-        case "viewpoint":
-          pointDocument.poiIconColor = "#008000";
-          pointDocument.poiIcon = "icon-viewpoint";
-          pointDocument.poiCategory = "Viewpoint";
-          return;
-        case "camp_site":
-          pointDocument.poiIconColor = "#734a08";
-          pointDocument.poiIcon = "icon-campsite";
-          pointDocument.poiCategory = "Camping";
-          return;
-        case "attraction":
-          pointDocument.poiIconColor = "#ffb800";
-          pointDocument.poiIcon = "icon-star";
-          pointDocument.poiCategory = "Other";
-          return;
-        case "artwork":
-          pointDocument.poiIconColor = "#ffb800";
-          pointDocument.poiIcon = "icon-artwork";
-          pointDocument.poiCategory = "Other";
-          return;
-        case "alpine_hut":
-          pointDocument.poiIconColor = "#734a08";
-          pointDocument.poiIcon = "icon-alpinehut";
-          pointDocument.poiCategory = "Camping";
-          return;
-      }
-    }
-
-    if (feature.getString("highway") != null) {
-      switch (feature.getString("highway")) {
-        case "cycleway":
-          pointDocument.poiIconColor = "black";
-          pointDocument.poiCategory = "Bicycle";
-          pointDocument.poiIcon = "icon-bike";
-          return;
-        case "footway":
-          pointDocument.poiIconColor = "black";
-          pointDocument.poiCategory = "Hiking";
-          pointDocument.poiIcon = "icon-hike";
-          return;
-        case "path":
-          pointDocument.poiIconColor = "black";
-          pointDocument.poiCategory = "Hiking";
-          pointDocument.poiIcon = "icon-hike";
-          return;
-        case "track":
-          pointDocument.poiIconColor = "black";
-          pointDocument.poiCategory = "4x4";
-          pointDocument.poiIcon = "icon-four-by-four";
-          return;
-      }
-    }
-
-    if ("place_of_worship".equals(feature.getString("amenity")) || "monastery".equals(feature.getString("amenity"))) {
-      var religion = feature.getString("religion") != null ? feature.getString("religion") : "";
-      pointDocument.poiCategory = "Other";
-      pointDocument.poiIconColor = "black";
-      switch (religion) {
-        case "jewish":
-          pointDocument.poiIcon = "icon-synagogue";
-          return;
-        case "christian":
-          pointDocument.poiIcon = "icon-church";
-          return;
-        case "muslim":
-          pointDocument.poiIcon = "icon-mosque";
-          return;
-        default:
-          pointDocument.poiIcon = "icon-holy-place";
-          return;
-      }
-    }
-
-    if (feature.getString("ref:IL:inature") != null) {
-      pointDocument.poiIconColor = "#116C00";
-      pointDocument.poiIcon = "icon-inature";
-      pointDocument.poiCategory = "iNature";
-      return;
-    }
-
-    pointDocument.poiIconColor = "black";
-    pointDocument.poiIcon = "icon-search";
-    pointDocument.poiCategory = "Other";
+    var category = OsmFeatureClassifier.classify(feature);
+    pointDocument.poiIcon = category.icon;
+    pointDocument.poiIconColor = category.color;
+    pointDocument.poiCategory = category.poiCategory;
   }
 
   /*

--- a/src/main/java/il/org/osm/israelhiking/PointDocument.java
+++ b/src/main/java/il/org/osm/israelhiking/PointDocument.java
@@ -1,9 +1,12 @@
 package il.org.osm.israelhiking;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 class PointDocument {
   public Map<String, String> name = new HashMap<String, String>();
   public Map<String, List<String>> alt_names;
@@ -20,7 +23,7 @@ class PointDocument {
   public double poiLength = 0;
   public String website;
   public double[] location;
-  public Float poiProminence;
+  public Float poiProminence = (float) ProminenceCalculator.PROMINENCE_FLOOR;
   public Float poiAreaNormalized;
   public Boolean intermittent;
   public Integer population;

--- a/src/main/java/il/org/osm/israelhiking/ProminenceCalculator.java
+++ b/src/main/java/il/org/osm/israelhiking/ProminenceCalculator.java
@@ -1,0 +1,31 @@
+package il.org.osm.israelhiking;
+
+final class ProminenceCalculator {
+
+  static final double QRANK_SCALE = 3_000_000.0;
+  static final double MAX_ELE_M = 8849.0;
+  static final double PROMINENCE_FLOOR = 0.05;
+  static final double WEIGHT_BASE = 0.45;
+  static final double WEIGHT_QRANK = 0.40;
+  static final double WEIGHT_META = 0.10;
+
+  private ProminenceCalculator() {}
+
+  static float compute(OsmFeatureClassifier.Category category, double ele, boolean hasImage,
+      boolean hasWebsite, boolean hasWikidata, long qrankRaw) {
+
+    double eleNormalized = Double.isNaN(ele) ? 0.0 : clamp01(Math.log1p(Math.max(0, ele)) / Math.log1p(MAX_ELE_M));
+    double base = clamp01(category.baseScore + category.elevationWeight * eleNormalized);
+    double qrankNormalized = (!hasWikidata || qrankRaw <= 1) ? 0.0 : clamp01(Math.log(qrankRaw) / Math.log(QRANK_SCALE));
+    double meta = clamp01(0.40 * (hasImage ? 1 : 0) + 0.35 * (hasWebsite ? 1 : 0) + 0.25 * (hasWikidata ? 1 : 0));
+
+    return (float) clamp01(PROMINENCE_FLOOR + WEIGHT_BASE * base + WEIGHT_QRANK * qrankNormalized + WEIGHT_META * meta);
+  }
+
+  static double clamp01(double v) {
+    if (Double.isNaN(v)) return 0;
+    if (v < 0) return 0;
+    if (v > 1) return 1;
+    return v;
+  }
+}

--- a/src/main/java/il/org/osm/israelhiking/QRankLookup.java
+++ b/src/main/java/il/org/osm/israelhiking/QRankLookup.java
@@ -1,0 +1,97 @@
+package il.org.osm.israelhiking;
+
+import com.carrotsearch.hppc.LongIntHashMap;
+import com.onthegomap.planetiler.collection.Hppc;
+import com.univocity.parsers.csv.CsvParser;
+import com.univocity.parsers.csv.CsvParserSettings;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Logger;
+import java.util.zip.GZIPInputStream;
+
+class QRankLookup {
+  private static final Logger LOGGER = Logger.getLogger(QRankLookup.class.getName());
+
+  private final LongIntHashMap qrankByQid;
+
+  private QRankLookup(LongIntHashMap qrankByQid) {
+    this.qrankByQid = qrankByQid;
+  }
+
+  static QRankLookup empty() {
+    return new QRankLookup(Hppc.newLongIntHashMap());
+  }
+
+  static QRankLookup load(Path csvGz) {
+    if (csvGz == null) {
+      LOGGER.info("QRankLookup: no QRank file configured — running with an empty lookup (lookups return 0)");
+      return empty();
+    }
+    long startMs = System.currentTimeMillis();
+    LongIntHashMap map = Hppc.newLongIntHashMap();
+    long rows = 0;
+    CsvParserSettings settings = new CsvParserSettings();
+    settings.setHeaderExtractionEnabled(true);
+    settings.setLineSeparatorDetectionEnabled(true);
+    settings.setReadInputOnSeparateThread(false);
+    settings.setAutoClosingEnabled(false);
+    CsvParser parser = new CsvParser(settings);
+    try (InputStream fis = Files.newInputStream(csvGz);
+        GZIPInputStream gz = new GZIPInputStream(fis, 1 << 16);
+        Reader reader = new InputStreamReader(gz, StandardCharsets.UTF_8)) {
+      parser.beginParsing(reader);
+      String[] row;
+      while ((row = parser.parseNext()) != null) {
+        if (row.length < 2 || row[0] == null || row[1] == null
+            || row[0].isEmpty() || row[0].charAt(0) != 'Q') {
+          continue;
+        }
+        try {
+          long qid = Long.parseLong(row[0], 1, row[0].length(), 10);
+          int qrank = Integer.parseInt(row[1]);
+          map.put(qid, qrank);
+          rows++;
+        } catch (NumberFormatException ignored) {
+        }
+      }
+      gz.transferTo(OutputStream.nullOutputStream());
+    } catch (Exception e) {
+      throw new IllegalArgumentException("QRankLookup: failed to read " + csvGz + " after " + rows
+          + " rows; fix --qrank-path or omit it", e);
+    }
+    long heapMb = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / (1024 * 1024);
+    LOGGER.info("QRankLookup: loaded " + rows + " rows from " + csvGz
+        + " in " + (System.currentTimeMillis() - startMs) + "ms (heap used ~" + heapMb + " MB)");
+    if (rows == 0) {
+      throw new IllegalArgumentException("QRankLookup: " + csvGz
+          + " yielded 0 usable rows (expected a gzipped 'Entity,QRank' CSV); fix --qrank-path or omit it");
+    }
+    return new QRankLookup(map);
+  }
+
+  long qrankFor(String wikidata) {
+    if (wikidata == null || wikidata.length() < 2 || wikidata.charAt(0) != 'Q') {
+      return 0;
+    }
+    int end = wikidata.indexOf(';');
+    if (end < 0) {
+      end = wikidata.length();
+    }
+    try {
+      long qid = Long.parseLong(wikidata, 1, end, 10);
+      return qrankByQid.getOrDefault(qid, 0);
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  int size() {
+    return qrankByQid.size();
+  }
+}

--- a/src/test/java/il/org/osm/israelhiking/OsmFeatureClassifierTest.java
+++ b/src/test/java/il/org/osm/israelhiking/OsmFeatureClassifierTest.java
@@ -1,0 +1,218 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.onthegomap.planetiler.reader.WithTags;
+
+@Tag("unit")
+public class OsmFeatureClassifierTest {
+
+    private static WithTags tags(String... kv) {
+        Map<String, Object> m = new HashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            m.put(kv[i], kv[i + 1]);
+        }
+        return WithTags.from(m);
+    }
+
+    private static Arguments row(String icon, String color, String category, String... kv) {
+        return Arguments.of(icon, color, category, kv);
+    }
+
+    static Stream<Arguments> iconGolden() {
+        return Stream.of(
+            row("icon-leaf", "#008000", "Other", "boundary", "protected_area"),
+            row("icon-leaf", "#008000", "Other", "boundary", "national_park"),
+            row("icon-leaf", "#008000", "Other", "leisure", "nature_reserve"),
+            row("icon-hike", "black", "Hiking", "route", "hiking"),
+            row("icon-hike", "black", "Hiking", "route", "foot"),
+            row("icon-bike", "black", "Bicycle", "route", "bicycle"),
+            row("icon-bike", "black", "Bicycle", "route", "mtb"),
+            row("icon-four-by-four", "black", "4x4", "route", "road", "scenic", "yes"),
+            row("icon-search", "black", "Other", "route", "road"),
+            row("icon-ruins", "#666666", "Historic", "historic", "ruins"),
+            row("icon-archaeological", "#666666", "Historic", "historic", "archaeological_site"),
+            row("icon-memorial", "#666666", "Historic", "historic", "memorial"),
+            row("icon-memorial", "#666666", "Historic", "historic", "monument"),
+            row("icon-cave", "black", "Natural", "historic", "tomb"),
+            row("icon-search", "black", "Other", "historic", "castle"),
+            row("icon-picnic", "#734a08", "Camping", "leisure", "picnic_table"),
+            row("icon-picnic", "#734a08", "Camping", "tourism", "picnic_site"),
+            row("icon-picnic", "#734a08", "Camping", "amenity", "picnic"),
+            row("icon-cave", "black", "Natural", "natural", "cave_entrance"),
+            row("icon-tint", "#1e80e3", "Water", "natural", "spring"),
+            row("icon-tree", "#008000", "Natural", "natural", "tree"),
+            row("icon-flowers", "#008000", "Natural", "natural", "flowers"),
+            row("icon-waterhole", "#1e80e3", "Water", "natural", "waterhole"),
+            row("icon-peak", "black", "Natural", "natural", "peak"),
+            row("icon-peak", "black", "Natural", "natural", "volcano"),
+            row("icon-peak", "black", "Natural", "natural", "ridge"),
+            row("icon-search", "black", "Other", "natural", "hot_spring"),
+            row("icon-search", "black", "Other", "natural", "valley"),
+            row("icon-tint", "#1e80e3", "Water", "water", "reservoir"),
+            row("icon-tint", "#1e80e3", "Water", "water", "pond"),
+            row("icon-tint", "#1e80e3", "Water", "water", "lake"),
+            row("icon-tint", "#1e80e3", "Water", "water", "stream_pool"),
+            row("icon-water-well", "#1e80e3", "Water", "man_made", "water_well"),
+            row("icon-cistern", "#1e80e3", "Water", "man_made", "cistern"),
+            row("icon-search", "black", "Other", "man_made", "tower"),
+            row("icon-waterfall", "#1e80e3", "Water", "waterway", "waterfall"),
+            row("icon-river", "#1e80e3", "Water", "type", "waterway"),
+            row("icon-search", "black", "Other", "waterway", "stream"),
+            row("icon-home", "black", "Wikipedia", "place", "city"),
+            row("icon-home", "black", "Wikipedia", "place", "town"),
+            row("icon-home", "black", "Wikipedia", "place", "village"),
+            row("icon-home", "black", "Wikipedia", "place", "hamlet"),
+            row("icon-home", "black", "Wikipedia", "place", "suburb"),
+            row("icon-home", "black", "Wikipedia", "place", ""),
+            row("icon-home", "black", "Wikipedia", "place", " "),
+            row("icon-viewpoint", "#008000", "Viewpoint", "tourism", "viewpoint"),
+            row("icon-campsite", "#734a08", "Camping", "tourism", "camp_site"),
+            row("icon-star", "#ffb800", "Other", "tourism", "attraction"),
+            row("icon-artwork", "#ffb800", "Other", "tourism", "artwork"),
+            row("icon-alpinehut", "#734a08", "Camping", "tourism", "alpine_hut"),
+            row("icon-search", "black", "Other", "tourism", "hotel"),
+            row("icon-bike", "black", "Bicycle", "highway", "cycleway"),
+            row("icon-hike", "black", "Hiking", "highway", "footway"),
+            row("icon-hike", "black", "Hiking", "highway", "path"),
+            row("icon-four-by-four", "black", "4x4", "highway", "track"),
+            row("icon-synagogue", "black", "Other", "amenity", "place_of_worship", "religion", "jewish"),
+            row("icon-church", "black", "Other", "amenity", "place_of_worship", "religion", "christian"),
+            row("icon-mosque", "black", "Other", "amenity", "place_of_worship", "religion", "muslim"),
+            row("icon-holy-place", "black", "Other", "amenity", "place_of_worship"),
+            row("icon-holy-place", "black", "Other", "amenity", "monastery"),
+            row("icon-inature", "#116C00", "iNature", "ref:IL:inature", "1234"),
+            row("icon-search", "black", "Other"),
+            row("icon-leaf", "#008000", "Other", "boundary", "national_park", "natural", "peak"),
+            row("icon-cave", "black", "Natural", "historic", "tomb", "natural", "spring"),
+            row("icon-ruins", "#666666", "Historic", "place", "city", "historic", "ruins"),
+            row("icon-peak", "black", "Natural", "natural", "peak", "place", "city"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("iconGolden")
+    public void iconClassificationIsStable(String icon, String color, String category, String[] kv) {
+        var c = OsmFeatureClassifier.classify(tags(kv));
+        assertEquals(icon, c.icon, "icon for " + Map.of("tags", String.join(",", kv)));
+        assertEquals(color, c.color, "color for " + String.join(",", kv));
+        assertEquals(category, c.poiCategory, "category for " + String.join(",", kv));
+    }
+
+    static Stream<Arguments> baseScoreAnchors() {
+        return Stream.of(
+            Arguments.of(0.80, new String[] { "boundary", "national_park" }),
+            Arguments.of(0.80, new String[] { "boundary", "protected_area" }),
+            Arguments.of(0.25, new String[] { "leisure", "nature_reserve" }),
+            Arguments.of(1.00, new String[] { "place", "city" }),
+            Arguments.of(0.80, new String[] { "place", "town" }),
+            Arguments.of(0.55, new String[] { "place", "village" }),
+            Arguments.of(0.35, new String[] { "place", "hamlet" }),
+            Arguments.of(0.45, new String[] { "place", "suburb" }),
+            Arguments.of(0.25, new String[] { "place", "" }),
+            Arguments.of(0.55, new String[] { "tourism", "viewpoint" }),
+            Arguments.of(0.55, new String[] { "tourism", "attraction" }),
+            Arguments.of(0.55, new String[] { "tourism", "alpine_hut" }),
+            Arguments.of(0.55, new String[] { "historic", "castle" }),
+            Arguments.of(0.55, new String[] { "historic", "ruins" }),
+            Arguments.of(0.30, new String[] { "natural", "spring" }),
+            Arguments.of(0.30, new String[] { "natural", "cave_entrance" }),
+            Arguments.of(0.30, new String[] { "natural", "hot_spring" }),
+            Arguments.of(0.30, new String[] { "waterway", "stream" }),
+            Arguments.of(0.30, new String[] { "natural", "peak" }),
+            Arguments.of(0.30, new String[] { "natural", "volcano" }),
+            Arguments.of(0.25, new String[] { "natural", "tree" }),
+            Arguments.of(0.25, new String[0]));
+    }
+
+    @ParameterizedTest
+    @MethodSource("baseScoreAnchors")
+    public void baseScoreMatchesLegacy(double expected, String[] kv) {
+        assertEquals(expected, OsmFeatureClassifier.classify(tags(kv)).baseScore, 1e-9,
+                "baseScore for " + String.join(",", kv));
+    }
+
+    static Stream<Arguments> multiTagBaseScoreShifts() {
+        return Stream.of(
+            Arguments.of(0.55, new String[] { "place", "city", "historic", "ruins" }),
+            Arguments.of(0.30, new String[] { "natural", "spring", "place", "city" }),
+            Arguments.of(0.80, new String[] { "boundary", "national_park", "place", "city" }),
+            Arguments.of(0.30, new String[] { "natural", "peak", "place", "city" }),
+            Arguments.of(0.25, new String[] { "leisure", "nature_reserve", "tourism", "viewpoint" }));
+    }
+
+    @ParameterizedTest
+    @MethodSource("multiTagBaseScoreShifts")
+    public void multiTagBaseScoreFollowsDisplayedCategory(double expected, String[] kv) {
+        assertEquals(expected, OsmFeatureClassifier.classify(tags(kv)).baseScore, 1e-9,
+                "multi-tag base score follows the displayed category for " + String.join(",", kv));
+    }
+
+    static Stream<Arguments> nonIconGolden() {
+        return Stream.of(
+            Arguments.of("icon-search", "black", "Other", new String[] { "amenity", "place_of_worship" }),
+            Arguments.of("icon-search", "black", "Other", new String[] { "natural", "valley" }),
+            Arguments.of("icon-search", "black", "Other", new String[] { "building", "yes" }),
+            Arguments.of("icon-bus-stop", "black", "Other", new String[] { "railway", "station" }),
+            Arguments.of("icon-bus-stop", "black", "Other", new String[] { "aerialway", "station" }),
+            Arguments.of("icon-peak", "black", "Other", new String[] { "natural", "ridge" }),
+            Arguments.of("icon-bike", "green", "Bicycle",
+                new String[] { "landuse", "recreation_ground", "sport", "mtb" }),
+            Arguments.of("icon-tree", "#008000", "Other", new String[] { "landuse", "forest" }),
+            Arguments.of("icon-wikipedia-w", "black", "Wikipedia",
+                new String[] { "amenity", "place_of_worship", "wikidata", "Q1" }),
+            Arguments.of("icon-wikipedia-w", "black", "Wikipedia",
+                new String[] { "building", "yes", "wikipedia", "en:X" }),
+            Arguments.of("icon-tree", "#008000", "Other",
+                new String[] { "landuse", "forest", "wikidata", "Q1" }),
+            Arguments.of("icon-bus-stop", "black", "Other",
+                new String[] { "building", "yes", "railway", "station" }));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonIconGolden")
+    public void nonIconClassificationIsStable(String icon, String color, String category, String[] kv) {
+        var c = OsmFeatureClassifier.classifyNonIcon(tags(kv));
+        assertEquals(icon, c.icon, "icon for " + String.join(",", kv));
+        assertEquals(color, c.color, "color for " + String.join(",", kv));
+        assertEquals(category, c.poiCategory, "category for " + String.join(",", kv));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonIndexableNonIcon")
+    public void nonIndexableFeaturesReturnNull(String[] kv) {
+        assertNull(OsmFeatureClassifier.classifyNonIcon(tags(kv)));
+    }
+
+    static Stream<Arguments> nonIndexableNonIcon() {
+        return Stream.of(
+            Arguments.of((Object) new String[0]),
+            Arguments.of((Object) new String[] { "building", "no" }),
+            Arguments.of((Object) new String[] { "amenity", "restaurant" }));
+    }
+
+    @Test
+    public void historicNonIconFeatureScoresViaHistoricFallbackNotItsDisplayCategory() {
+        WithTags historicBuilding = tags("building", "yes", "historic", "manor", "name", "Old Manor");
+
+        OsmFeatureClassifier.Category display = OsmFeatureClassifier.classifyNonIcon(historicBuilding);
+        OsmFeatureClassifier.Category scoring = OsmFeatureClassifier.classify(historicBuilding);
+
+        assertEquals(OsmFeatureClassifier.Category.NONICON_GENERIC, display);
+        assertEquals(OsmFeatureClassifier.Category.FALLBACK_HISTORIC, scoring);
+        assertTrue(scoring.baseScore > display.baseScore,
+                "a historic non-icon feature is scored via the historic fallback " + scoring.baseScore
+                        + ", outranking a plain non-icon's " + display.baseScore);
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/OsmNumberParserTest.java
+++ b/src/test/java/il/org/osm/israelhiking/OsmNumberParserTest.java
@@ -1,0 +1,94 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@Tag("unit")
+public class OsmNumberParserTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "4302, 4302",
+        "'14,115', 14115",
+        "'1 000', 1000",
+        "14115 ft, 14115",
+        "'1,234 m', 1234",
+        "'5000 (2011)', 5000",
+        "1.234, 1234",
+        "'12''345', 12345",
+    })
+    public void populationParsesToPositiveInt(String raw, int expected) {
+        var parsed = OsmNumberParser.parsePopulation(raw);
+        assertTrue(parsed.isPresent(), "expected a population for " + raw);
+        assertEquals(expected, parsed.getAsInt());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "yes",
+        "abc",
+        "0",
+        "-5",
+        "''",
+    })
+    public void populationRejectsNonPositiveOrNonNumeric(String raw) {
+        assertFalse(OsmNumberParser.parsePopulation(raw).isPresent(), "did not expect a population for " + raw);
+    }
+
+    @Test
+    public void populationRejectsNull() {
+        assertFalse(OsmNumberParser.parsePopulation(null).isPresent());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "4302, 4302.0",
+        "4302.3, 4302.3",
+        "'14,115', 14115.0",
+        "'1 000', 1000.0",
+        "'1,234 m', 1234.0",
+        "-430, -430.0",
+        "-430 m, -430.0",
+        "'-1,234', -1234.0",
+        "100-200, 100.0",
+        "- 430, 430.0",
+    })
+    public void elevationParsesMetres(String raw, double expected) {
+        var parsed = OsmNumberParser.parseElevation(raw);
+        assertTrue(parsed.isPresent(), "expected an elevation for " + raw);
+        assertEquals(expected, parsed.getAsDouble(), 1e-9);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "14115 ft, 4302.252",
+        "1000 ft, 304.8",
+        "500 feet, 152.4",
+        "3000', 914.4",
+    })
+    public void elevationConvertsFeetToMetres(String raw, double expectedMetres) {
+        assertEquals(expectedMetres, OsmNumberParser.parseElevation(raw).getAsDouble(), 1e-3,
+                "feet must be converted to metres for " + raw);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "yes",
+        "abc",
+        "''",
+    })
+    public void elevationRejectsNonNumeric(String raw) {
+        assertFalse(OsmNumberParser.parseElevation(raw).isPresent());
+    }
+
+    @Test
+    public void elevationRejectsNull() {
+        assertFalse(OsmNumberParser.parseElevation(null).isPresent());
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/ProminenceCalculatorTest.java
+++ b/src/test/java/il/org/osm/israelhiking/ProminenceCalculatorTest.java
@@ -1,0 +1,108 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import il.org.osm.israelhiking.OsmFeatureClassifier.Category;
+
+@Tag("unit")
+public class ProminenceCalculatorTest {
+
+    private static final double NO_ELE = Double.NaN;
+
+    @Test
+    public void famousPeakWithQRankRanksHigh() {
+        float prominence = ProminenceCalculator.compute(Category.PEAK, 4302, true, false, true, 359_540L);
+        assertTrue(prominence > 0.7, "famous high peak should score high, was " + prominence);
+    }
+
+    @Test
+    public void duplicateNodeWithNoSignalScoresLow() {
+        float low = ProminenceCalculator.compute(Category.FALLBACK, NO_ELE, false, false, false, 0L);
+        assertEquals(0.1625f, low, 1e-4, "a node with no signal should score at the baseline");
+        float famous = ProminenceCalculator.compute(Category.PEAK, 4302, true, false, true, 359_540L);
+        assertTrue(famous > low * 3, "famous peak must dominate an unsignalled node");
+    }
+
+    @Test
+    public void prominenceIsNeverZero() {
+        float prominence = ProminenceCalculator.compute(Category.FALLBACK, NO_ELE, false, false, false, 0L);
+        assertTrue(prominence >= ProminenceCalculator.PROMINENCE_FLOOR);
+        assertTrue(prominence > 0f);
+    }
+
+    @Test
+    public void everyCategoryClearsTheFloor() {
+        for (Category category : Category.values()) {
+            float prominence = ProminenceCalculator.compute(category, NO_ELE, false, false, false, 0L);
+            assertTrue(prominence >= (float) ProminenceCalculator.PROMINENCE_FLOOR,
+                    category + " scored below the floor: " + prominence);
+        }
+    }
+
+    @Test
+    public void cityOutranksVillage() {
+        float city = ProminenceCalculator.compute(Category.PLACE_CITY, NO_ELE, false, false, false, 0L);
+        float village = ProminenceCalculator.compute(Category.PLACE_VILLAGE, NO_ELE, false, false, false, 0L);
+        assertTrue(city > village, "city " + city + " should outrank village " + village);
+    }
+
+    @Test
+    public void higherPeakOutranksLowerPeak() {
+        float high = ProminenceCalculator.compute(Category.PEAK, 4000, false, false, false, 0L);
+        float low = ProminenceCalculator.compute(Category.PEAK, 200, false, false, false, 0L);
+        assertTrue(high > low, "a 4000m peak should outrank a 200m hill");
+    }
+
+    @Test
+    public void nationalParkScoresAboveGenericNode() {
+        float park = ProminenceCalculator.compute(Category.NATURE_RESERVE, NO_ELE, false, false, false, 0L);
+        float generic = ProminenceCalculator.compute(Category.FALLBACK, NO_ELE, false, false, false, 0L);
+        assertTrue(park > generic);
+    }
+
+    @Test
+    public void qrankOnlyCountsWithWikidataPresence() {
+        float withQ = ProminenceCalculator.compute(Category.NATURAL_SPRING, NO_ELE, false, false, true, 50_000L);
+        float noQ = ProminenceCalculator.compute(Category.NATURAL_SPRING, NO_ELE, false, false, true, 0L);
+        assertTrue(withQ > noQ, "a popular spring should beat an obscure one");
+    }
+
+    @Test
+    public void qrankIgnoredWhenWikidataAbsent() {
+        float withQrank = ProminenceCalculator.compute(Category.NATURAL_SPRING, NO_ELE, false, false, false, 1_000_000L);
+        float withoutQrank = ProminenceCalculator.compute(Category.NATURAL_SPRING, NO_ELE, false, false, false, 0L);
+        assertEquals(withoutQrank, withQrank, 1e-6f, "QRank must not affect a feature with no wikidata");
+    }
+
+    @Test
+    public void belowSeaLevelPeakIsFlooredToZeroElevation() {
+        float below = ProminenceCalculator.compute(Category.PEAK, -430, false, false, false, 0L);
+        float atSeaLevel = ProminenceCalculator.compute(Category.PEAK, 0, false, false, false, 0L);
+        assertEquals(atSeaLevel, below, 1e-6f,
+                "a -430m peak must score the same as a 0m peak, not get a +430m elevation boost");
+    }
+
+    @Test
+    public void peakScalesWithElevation() {
+        float high = ProminenceCalculator.compute(Category.PEAK, 8849, false, false, false, 0L);
+        float sea = ProminenceCalculator.compute(Category.PEAK, 0, false, false, false, 0L);
+        assertTrue(high > sea, "elevation must lift a peak's prominence");
+    }
+
+    @Test
+    public void outputAlwaysInUnitRange() {
+        float prominence = ProminenceCalculator.compute(Category.PEAK, 8849, true, true, true, Long.MAX_VALUE);
+        assertTrue(prominence >= 0f && prominence <= 1f, "prominence out of range: " + prominence);
+    }
+
+    @Test
+    public void clamp01BoundsBothEnds() {
+        assertEquals(0.0, ProminenceCalculator.clamp01(-1.0), 1e-9, "a negative input clamps to 0");
+        assertEquals(1.0, ProminenceCalculator.clamp01(2.0), 1e-9, "an above-one input clamps to 1");
+        assertEquals(0.5, ProminenceCalculator.clamp01(0.5), 1e-9, "an in-range value passes through");
+    }
+}

--- a/src/test/java/il/org/osm/israelhiking/QRankLookupTest.java
+++ b/src/test/java/il/org/osm/israelhiking/QRankLookupTest.java
@@ -1,0 +1,108 @@
+package il.org.osm.israelhiking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.zip.GZIPOutputStream;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("unit")
+public class QRankLookupTest {
+
+    private static Path writeGzip(Path dir, String content) throws IOException {
+        Path gz = dir.resolve("qrank.csv.gz");
+        try (OutputStream os = Files.newOutputStream(gz);
+                GZIPOutputStream gzos = new GZIPOutputStream(os)) {
+            gzos.write(content.getBytes(StandardCharsets.UTF_8));
+        }
+        return gz;
+    }
+
+    @Test
+    public void emptyLookupReturnsZero() {
+        var lookup = QRankLookup.empty();
+        assertEquals(0, lookup.qrankFor("Q665321"));
+        assertEquals(0, lookup.size());
+    }
+
+    @Test
+    public void nullPathYieldsEmptyLookupNoException() {
+        var lookup = QRankLookup.load(null);
+        assertEquals(0, lookup.size());
+        assertEquals(0, lookup.qrankFor("Q42"));
+    }
+
+    @Test
+    public void missingFileFailsFast(@TempDir Path dir) {
+        var missing = dir.resolve("does-not-exist.csv.gz");
+        assertThrows(IllegalArgumentException.class, () -> QRankLookup.load(missing),
+                "a configured-but-missing qrank-path must fail fast, not silently floor every feature");
+    }
+
+    @Test
+    public void looksUpVariousWikidataFormsFromOneFile(@TempDir Path dir) throws IOException {
+        var lookup = QRankLookup.load(
+                writeGzip(dir, "Entity,QRank\nQ665321,359540\nQ121211166,34\nQ42,1000000\n"));
+
+        assertEquals(3, lookup.size());
+        assertEquals(359540, lookup.qrankFor("Q665321"));
+        assertEquals(34, lookup.qrankFor("Q121211166"));
+        assertEquals(1000000, lookup.qrankFor("Q42"));
+        assertEquals(1000000, lookup.qrankFor("Q42;Q43"),
+                "a semicolon-joined wikidata tag must resolve to the first QID's rank");
+        assertEquals(0, lookup.qrankFor("Q999"), "unknown id -> 0");
+        assertEquals(0, lookup.qrankFor(null), "null -> 0");
+        assertEquals(0, lookup.qrankFor(""), "empty -> 0");
+        assertEquals(0, lookup.qrankFor("notaqid"), "malformed -> 0");
+        assertEquals(0, lookup.qrankFor("Qx"), "a Q-prefixed but non-numeric id must return 0, not throw");
+    }
+
+    @Test
+    public void headerOnlyFileFailsFast(@TempDir Path dir) throws IOException {
+        Path gz = writeGzip(dir, "Entity,QRank\n");
+        assertThrows(IllegalArgumentException.class, () -> QRankLookup.load(gz),
+                "a configured file with no data rows must fail fast, not silently floor every feature");
+    }
+
+    @Test
+    public void malformedDataRowsAreSkipped(@TempDir Path dir) throws IOException {
+        var lookup = QRankLookup.load(writeGzip(dir, "Entity,QRank\nQ,5\nX9,5\nQ7,42\n"));
+        assertEquals(1, lookup.size(), "a no-QID row and a non-Q row must both be skipped");
+        assertEquals(42, lookup.qrankFor("Q7"));
+        assertEquals(0, lookup.qrankFor("Q9"), "the X9 row must never have been indexed under Q9");
+    }
+
+    @Test
+    public void rowWithNonNumericValueIsSkipped(@TempDir Path dir) throws IOException {
+        var lookup = QRankLookup.load(writeGzip(dir, "Entity,QRank\nQ5,abc\nQ7,42\n"));
+        assertEquals(1, lookup.size(), "a Q-row with an unparseable rank must be skipped, not abort the load");
+        assertEquals(0, lookup.qrankFor("Q5"));
+        assertEquals(42, lookup.qrankFor("Q7"), "the valid row after a bad one must still load");
+    }
+
+    @Test
+    public void corruptFileFailsFast(@TempDir Path dir) throws IOException {
+        Path notGzip = dir.resolve("qrank.csv.gz");
+        Files.writeString(notGzip, "this is plainly not gzip data");
+        assertThrows(IllegalArgumentException.class, () -> QRankLookup.load(notGzip),
+                "a configured-but-corrupt file must fail fast, not silently floor every feature");
+    }
+
+    @Test
+    public void truncatedGzipFailsFast(@TempDir Path dir) throws IOException {
+        Path gz = writeGzip(dir, "Entity,QRank\nQ1,10\nQ2,20\nQ3,30\nQ4,40\n");
+        byte[] full = Files.readAllBytes(gz);
+        Files.write(gz, Arrays.copyOf(full, full.length - 6));
+        assertThrows(IllegalArgumentException.class, () -> QRankLookup.load(gz),
+                "a truncated/partial qrank.csv.gz must fail fast, not load a partial ranking");
+    }
+}


### PR DESCRIPTION
## What

Index-time **prominence** + **QRank** ranking signal (`poiProminence`) and **population** — populating fields that `main` already maps (via #72/#73/#75) but never fills.

This is a clean re-derivation of #78 on top of `main`, addressing that review:
- **Prominence only.** The lossless-reindex / `BulkIngester` work is split out and tracked in #80 — it is **not** in this PR.
- **Debug breakdown fields removed** from `PointDocument` (they were debug-only).
- **`ProminenceCalculator.Result` is a `record`.**
- No unrelated indexer tests.

## Signals

- `QRankIndex` — loads a gzipped `qrank.csv.gz` (`--qrank-path`, optional) into a primitive `long` map keyed by Wikidata QID. Omit the flag and the build runs unchanged without the file.
- `ProminenceCalculator` — base score (feature type + elevation) + QRank (only when wikidata is present) + metadata → a `0..1` `poiProminence`.
- `population` — parsed from `population` / `place` tags with per-place fallbacks.
- `@JsonInclude(NON_NULL)` on `PointDocument` + a `flooredProminence` net so a null prominence can't fall back to `field_value_factor` `missing:1.0` and outrank scored features.

No transport/indexer changes — inserts use the existing path.

## Tests

`ProminenceCalculatorTest`, `QRankIndexTest`, `ParseFirstNumberTest`, `InsertProminenceFloorTest` (`@Tag("unit")`, zero network). `mvn test`: **46 tests, 0 failures**.

Supersedes #78 (which will be closed).
