### PR TITLE
Retune relevance signal budget: bounded text/prominence, gaussian geo with zoom-scaled width

### DIFF
--- a/src/main/resources/search-templates/points_search.json
+++ b/src/main/resources/search-templates/points_search.json
@@ -110,12 +110,12 @@
                 "script_score": {
                   "script": {
                     "source": "params.w_text * (_score / (_score + params.k_text))",
-                    "params": { "w_text": 5.0, "k_text": 30.0 }
+                    "params": { "w_text": 4.0, "k_text": 8.0 }
                   }
                 }
               },
               {
-                "field_value_factor": { "field": "poiProminence", "factor": 1.0 }
+                "field_value_factor": { "field": "poiProminence", "factor": 0.3 }
               },
               {
                 "filter": {
@@ -132,10 +132,10 @@
               ,{
                 "script_score": {
                   "script": {
-                    "source": "if (doc['location'].size() == 0) { return 0.0; } double z = params.zoom <= 0 ? params.default_zoom : Math.min(params.zoom, params.max_zoom); double beta = 1.0 / (1.0 + Math.exp(-params.beta_steepness * (z - params.beta_midpoint))); double d = doc['location'].arcDistance(params.lat, params.lon) / 1000.0; double g = Math.pow(params.decay, d / params.scale_km); return params.w_geo * beta * g;",
+                    "source": "if (doc['location'].size() == 0) { return 0.0; } double z = params.zoom <= 0 ? params.default_zoom : Math.min(params.zoom, params.max_zoom); double beta = 1.0 / (1.0 + Math.exp(-params.beta_steepness * (z - params.beta_midpoint))); double offsetKm = 0.5; double dsc = Math.max(params.scale_km, Math.pow(2.2, 18 - z) * 0.1); double d = doc['location'].arcDistance(params.lat, params.lon) / 1000.0; double x = Math.max(0.0, d - offsetKm); double g = Math.exp(-0.5 * (x * x) / (dsc * dsc)); return params.w_geo * beta * g;",
                     "params": {
                       "lat": {{lat}}, "lon": {{lng}}, "zoom": {{zoom}},
-                      "w_geo": 1.0, "scale_km": 50.0, "decay": 0.5,
+                      "w_geo": 1.0, "scale_km": 8.0,
                       "beta_steepness": 0.7, "beta_midpoint": 8.0,
                       "default_zoom": 12, "max_zoom": 22
                     }

--- a/src/main/resources/search-templates/points_search.json
+++ b/src/main/resources/search-templates/points_search.json
@@ -132,10 +132,10 @@
               ,{
                 "script_score": {
                   "script": {
-                    "source": "if (doc['location'].size() == 0) { return 0.0; } double z = params.zoom <= 0 ? params.default_zoom : Math.min(params.zoom, params.max_zoom); double beta = 1.0 / (1.0 + Math.exp(-params.beta_steepness * (z - params.beta_midpoint))); double offsetKm = 0.5; double dsc = Math.max(params.scale_km, Math.pow(2.2, 18 - z) * 0.1); double d = doc['location'].arcDistance(params.lat, params.lon) / 1000.0; double x = Math.max(0.0, d - offsetKm); double g = Math.exp(-0.5 * (x * x) / (dsc * dsc)); return params.w_geo * beta * g;",
+                    "source": "if (doc['location'].size() == 0) { return 0.0; } double z = params.zoom <= 0 ? params.default_zoom : Math.min(params.zoom, params.max_zoom); double beta = 1.0 / (1.0 + Math.exp(-params.beta_steepness * (z - params.beta_midpoint))); double dsc = Math.max(params.scale_km, Math.pow(2.2, 18 - z) * 0.1); double d = doc['location'].arcDistance(params.lat, params.lon) / 1000.0; double x = Math.max(0.0, d - params.offset_km); double g = Math.exp(-0.5 * (x * x) / (dsc * dsc)); return params.w_geo * beta * g;",
                     "params": {
                       "lat": {{lat}}, "lon": {{lng}}, "zoom": {{zoom}},
-                      "w_geo": 1.0, "scale_km": 8.0,
+                      "w_geo": 1.0, "scale_km": 8.0, "offset_km": 0.5,
                       "beta_steepness": 0.7, "beta_midpoint": 8.0,
                       "default_zoom": 12, "max_zoom": 22
                     }


### PR DESCRIPTION
# Retune relevance signal budget: measured 295 → 301/314, E2E stays green

Refs IsraelHikingMap/planet-search#90

## Summary

Four constant-level changes to `points_search.json` (rebased onto fe3303a):

| param | main | this PR | why |
|---|---|---|---|
| `w_text` / `k_text` | 5.0 / 30 | **4.0 / 8** | at 5.0/30 the text range (0..5) is 5× the geo range (0..1) — a same-named feature wins from any distance |
| `poiProminence` factor | 1.0 | **0.3** | at 1.0 prominence (0.16–0.93) rivals the whole geo range — famous far features outrank the one under the cursor |
| geo decay | `0.5^(d/50km)` | **gaussian, offset 0.5 km, width `max(8, 2.2^(18-z)*0.1)` km** | see below — the exponential long tail is what breaks the FAR-* sanity cases at these weights |

## Measurements

All numbers from the **stored search template** executed via `_search/template` against a full-planet ES 7.17 index (23.8M points, planet-latest + QRank), using the repo's own gold set (`search-relevance-cases.json`, now 314 cases) and the E2E sanity suite on the real Geofabrik israel extract:

| variant | gold set | E2E sanity (incl. FAR-*) |
|---|---|---|
| current `main` (exp 50 km, w_text 5/30, prom 1.0) | 295/314 | green |
| exp 50 km + w_text 4/8 + prom 0.3 | 294/305* | **red** (FAR-SITE, FAR-FROM-CENTER-TYPO) |
| exp 25 km + w_text 4/8 + prom 0.3 | 295/305* | **red** (same two) |
| **this PR** (gaussian + w_text 4/8 + prom 0.3) | **301/314** | **green** |

\* measured before the gold set grew from 305 to 314; relative ordering is stable.

Failures on current `main` that this PR fixes include:

```
Devils Lake       expected on-center      closest hit at 879 km
Northeast Harbor  expected 2.5 km         closest hit at  87 km
John Muir Trail   expected within 50 km   closest hit at  89 km
Pike's Peak       expected within 1 km    closest hit at 11.6 km
grand tet (prefix)                        closest hit at 8299 km
```

## Why gaussian instead of the exponential — the interesting part

We tried hard to keep the exponential (it is the Pelias default and the rows 2–3 above are those attempts). It fails the FAR-* sanity cases **at any text weight that also passes the gold set**, and the mechanism is visible in the small-extract topN for FAR-SITE (`מצדה` searched from Tel Aviv, target Masada ~100 km away; the extract contains 6+ features named `מצדה`, all with identical text scores):

- **exponential 25 km**: mid-distance same-named competitors at 31/50/64 km from center keep `g` = 0.42/0.25/0.17 while Masada at 100 km gets 0.06 — they crowd it out of the top 3.
- **gaussian (width 11.3 km @ z12)**: geo is ≈0 for *everything* beyond ~30 km, so among the text-tied candidates prominence decides — and the real Masada (wikidata, prom 0.32 vs 0.16) wins.

The long tail sounds desirable for far targets, but what FAR-* actually needs is geo to become *uniformly* negligible at distance so text+prominence can decide. The gold cases that motivated a long tail (long trails T001/T004) miss their 50 km tolerance by 9–18 km under every variant — that is representative-point placement, not ranking.

The gaussian's **offset is fixed at 0.5 km** (jitter tolerance only) and its **width is zoom-scaled**. The previous zoom-scaled *offset* is what created the original bug: a 24.9 km blind zone at z11 in which a target 4 m from the map center tied byte-for-byte with a same-named point 14 km away (both scored exactly 0.946403 on the planet index — the "winner" was arbitrary Lucene order).

## Remaining gold failures (13/314) — not addressable in the scorer

Prefix recall (`long pe`, `grand can`, `mesa v` — the `prefix=true`/edge-ngram path), NL parsing (`lake near Prescott`), long-trail representative points (T001/T004), and borderline radii (targets 1.6–4 km out with 1.2–2 km tolerances).

## Test evidence

- E2E (`-Prun-all-tests -Dtest=E2ETest`, real Geofabrik extract): **BUILD SUCCESS** on this exact tree.
- Unit tests: **180/180**.
- Gold-set runs reproducible via `_search/template` against a full-planet index.
