### PR TITLE
Fold bbox infomation into the point index

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Additional arguments to this wrapper besides the Planetiler's arguments:
 | `external-file-path` | External geojson file path to allow adding non OSM features to the search and POIs. these features should have a specific format | "empty" |
 | `skip-tiles` | Collapse the tile pyramid to z0 so the `.pmtiles` archive is a near-instant stub, to speed up an Elasticsearch-only reindex. The search index is built identically; only the map tiles degrade, so do not use it for a build whose map tiles are consumed. | `false` |
 | `qrank-path` | Path to a gzipped `qrank.csv.gz` used to compute the `poiProminence` ranking signal. Optional — leave empty to build without it (every point still gets a base+metadata prominence; only the QRank signal is omitted). | "empty" |
+| `container-index-path` | Path to the container index the previous build wrote; it is loaded to tag every point with the places that contain it, and rewritten from this build's containers for the next build. Defaulted per `area`, since each area has its own containers. See [Containers on points](#containers-on-points). | `data/sources/container-index-<area>.bin.gz` |
 | `update-templates-only` | Store the search templates of this build in Elasticsearch and exit, without building anything. Updates the queries of a live index without a reindex | `false` |
 
 The QRank data file comes from [https://qrank.toolforge.org](https://qrank.toolforge.org) (CC0): a gzipped CSV (`Entity,QRank`) ranking Wikidata entities by aggregated Wikimedia pageviews. `qrank-path` is optional and fully omittable — omit it and the build runs unchanged without the ~363 MB file.
@@ -35,9 +36,8 @@ curl -s localhost:9200/points/_search/template -H 'Content-Type: application/jso
 
 | Template | Used for | Parameters |
 |-|-|-|
-| `points_search` | The main search. Add `hasPlaceShape` + `placeShape` to limit it to a container, i.e. the second half of a "point, place" search | `searchTerm`, `prefix`, `hasCenter`, `lat`, `lng`, `zoom`, `hasPlaceShape`, `placeShape` |
+| `points_search` | The main search. Add `place` to limit it to a container — a "point, place" search that resolves in one query, since every point already carries its containers (see [Containers on points](#containers-on-points)) | `searchTerm`, `prefix`, `hasCenter`, `lat`, `lng`, `zoom`, `place` |
 | `points_search_exact` | A quoted search, matches the whole name only | `searchTerm` |
-| `bbox_container` | Finds the container of a "point, place" search | `place`, `prefix` |
 | `bbox_contains` | Finds the container of a coordinate, i.e. which place a point is in | `shape` |
 
 Each template is a self contained query, tuning included, with two kinds of placeholders:
@@ -80,6 +80,18 @@ The templates are tested by [E2ETest.java](src/test/java/il/org/osm/israelhiking
 Adding a case is adding a line to that file. It runs on every pull request, and locally with:
 
 `docker compose up -d elasticsearch && mvn test -Prun-all-tests -Dtest=E2ETest`
+
+## Containers on points
+
+Every point is tagged at build time with the places that contain it, so a "point, place" search — say "spring, Jerusalem" — is a single query: `points_search` filters on the point's containers with the `place` parameter. Each point carries:
+
+- `poiParentNames` — every place it falls inside, per language; this is what `place` matches against.
+- `poiContainer` — the tightest place around it, for display.
+- `poiCountry` — the country, for display, shown next to the container when they differ.
+
+Point-in-polygon can't run in the single streaming pass, because a point is read before the boundary that contains it is assembled. So containers are carried between builds: a build collects its containers — admin boundaries up to level 8, settlements, parks and reserves — into `container-index-path`, and the next build loads that file into an in-memory spatial index and tags its points from it. Containers change rarely, so the one-build lag is by design.
+
+The catch is that a fresh deployment needs **two build cycles** to fully populate: the first writes the container index while its own points go untagged, and the second tags its points from that file. The end to end test exercises this by building twice.
 
 ## External features file format
 

--- a/src/main/java/il/org/osm/israelhiking/ContainerIndex.java
+++ b/src/main/java/il/org/osm/israelhiking/ContainerIndex.java
@@ -1,0 +1,175 @@
+package il.org.osm.israelhiking;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.prep.PreparedGeometry;
+import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
+import org.locationtech.jts.index.strtree.STRtree;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKBReader;
+import org.locationtech.jts.io.WKBWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The container side of a build, both halves in one object: it {@link #load}s
+ * the previous build's containers into a queryable spatial index (used by
+ * {@link #containing} to tag each point), and {@link #add}s the containers this
+ * build sees so {@link #write} can persist them for the next build. Containers
+ * change rarely, so the one-build lag is acceptable.
+ *
+ * <p>Built once (single-threaded), then both queried and appended concurrently
+ * from the Planetiler worker threads: {@link STRtree} queries and
+ * {@link PreparedGeometry#contains} are thread-safe once the tree is built, and
+ * the append side is a {@link ConcurrentLinkedQueue}.
+ */
+final class ContainerIndex {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ContainerIndex.class);
+  private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
+
+  /**
+   * A place a point can fall inside — an admin boundary, a settlement polygon, a
+   * park. Carries only what point enrichment needs: the localized names, the
+   * admin level (2 == country, 0 when the container is not an admin boundary),
+   * the area in m² (used to pick the tightest container), and a simplified
+   * polygon for the containment test.
+   */
+  static final class ContainerRecord {
+
+    static final int COUNTRY_ADMIN_LEVEL = 2;
+
+    final Map<String, String> names;
+    final int adminLevel;
+    final double area;
+    final Geometry geometry;
+
+    ContainerRecord(Map<String, String> names, int adminLevel, double area, Geometry geometry) {
+      this.names = names;
+      this.adminLevel = adminLevel;
+      this.area = area;
+      this.geometry = geometry;
+    }
+
+    boolean isCountry() {
+      return adminLevel == COUNTRY_ADMIN_LEVEL;
+    }
+  }
+
+  private record Entry(ContainerRecord record, PreparedGeometry prepared) {
+  }
+
+  private final STRtree tree = new STRtree();
+  private final int loadedCount;
+  private final Collection<ContainerRecord> collected = new ConcurrentLinkedQueue<>();
+
+  private ContainerIndex(Collection<ContainerRecord> loaded) {
+    for (ContainerRecord record : loaded) {
+      tree.insert(record.geometry.getEnvelopeInternal(),
+          new Entry(record, PreparedGeometryFactory.prepare(record.geometry)));
+    }
+    tree.build();
+    this.loadedCount = loaded.size();
+  }
+
+  /** Loads the previous build's containers for lookup; a missing file yields an empty index. */
+  static ContainerIndex load(Path path) throws IOException {
+    if (path == null || !Files.exists(path)) {
+      LOGGER.info("Container index: none at {} — this build tags no points and will produce it", path);
+      return new ContainerIndex(List.of());
+    }
+    List<ContainerRecord> records = read(path);
+    LOGGER.info("Container index: loaded {} containers from {}", records.size(), path);
+    return new ContainerIndex(records);
+  }
+
+  /** Remembers a container seen in this build, to be persisted by {@link #write}. */
+  void add(ContainerRecord record) {
+    collected.add(record);
+  }
+
+  /** The containers that enclose the given coordinate, in no particular order. */
+  List<ContainerRecord> containing(double lat, double lng) {
+    if (loadedCount == 0) {
+      return List.of();
+    }
+    Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(lng, lat));
+    List<ContainerRecord> hits = new ArrayList<>();
+    for (Object candidate : tree.query(point.getEnvelopeInternal())) {
+      Entry entry = (Entry) candidate;
+      if (entry.prepared().contains(point)) {
+        hits.add(entry.record());
+      }
+    }
+    return hits;
+  }
+
+  /** Persists the containers collected in this build for the next build to load. */
+  void write(Path path) throws IOException {
+    List<ContainerRecord> snapshot = new ArrayList<>(collected);
+    WKBWriter wkbWriter = new WKBWriter();
+    try (DataOutputStream out = new DataOutputStream(
+        new BufferedOutputStream(new GZIPOutputStream(Files.newOutputStream(path))))) {
+      out.writeInt(snapshot.size());
+      for (ContainerRecord record : snapshot) {
+        byte[] wkb = wkbWriter.write(record.geometry);
+        out.writeInt(wkb.length);
+        out.write(wkb);
+        out.writeInt(record.adminLevel);
+        out.writeDouble(record.area);
+        out.writeInt(record.names.size());
+        for (Map.Entry<String, String> name : record.names.entrySet()) {
+          out.writeUTF(name.getKey());
+          out.writeUTF(name.getValue());
+        }
+      }
+    }
+    LOGGER.info("Container index: wrote {} containers to {}", snapshot.size(), path);
+  }
+
+  private static List<ContainerRecord> read(Path path) throws IOException {
+    WKBReader wkbReader = new WKBReader(GEOMETRY_FACTORY);
+    List<ContainerRecord> records = new ArrayList<>();
+    try (DataInputStream in = new DataInputStream(
+        new BufferedInputStream(new GZIPInputStream(Files.newInputStream(path))))) {
+      int count = in.readInt();
+      for (int i = 0; i < count; i++) {
+        byte[] wkb = new byte[in.readInt()];
+        in.readFully(wkb);
+        Geometry geometry;
+        try {
+          geometry = wkbReader.read(wkb);
+        } catch (ParseException e) {
+          throw new IOException("corrupt container geometry at record " + i, e);
+        }
+        int adminLevel = in.readInt();
+        double area = in.readDouble();
+        int nameCount = in.readInt();
+        Map<String, String> names = new LinkedHashMap<>(nameCount);
+        for (int n = 0; n < nameCount; n++) {
+          names.put(in.readUTF(), in.readUTF());
+        }
+        records.add(new ContainerRecord(names, adminLevel, area, geometry));
+      }
+    }
+    return records;
+  }
+}

--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -34,7 +34,8 @@ public class ElasticsearchHelper {
       String bboxIndexTarget,
       String[] supportedLanguages,
       QRankLookup qrankLookup,
-      BulkIndexer bulkListener) {
+      BulkIndexer bulkListener,
+      ContainerIndex containerIndex) {
   }
 
   /**
@@ -139,6 +140,10 @@ public class ElasticsearchHelper {
                         .text(pt -> pt
                             .analyzer("prefix_index_analyzer")
                             .searchAnalyzer("prefix_search_analyzer")))));
+            m.properties("parentNames." + lang, k -> k
+                .text(p -> p.analyzer("universal_analyzer")));
+            m.properties("container." + lang, k -> k.keyword(kw -> kw));
+            m.properties("country." + lang, k -> k.keyword(kw -> kw));
           }
           m.properties("location", g -> g.geoPoint(p -> p));
           m.properties("poiProminence", n -> n.float_(f -> f));
@@ -204,16 +209,17 @@ public class ElasticsearchHelper {
   }
 
   public static ElasticRunContext initRun(ElasticsearchClient esClient,
+      BulkIndexer bulkListener,
       String pointsIndexAlias,
       String bboxIndexAlias,
       String[] supportedLanguages,
-      QRankLookup qrankLookup) throws Exception {
+      QRankLookup qrankLookup,
+      ContainerIndex containerIndex) throws Exception {
     var targetPointsIndex = ElasticsearchHelper.createPointsIndex(esClient, pointsIndexAlias,
         supportedLanguages);
     var targetBBoxIndex = ElasticsearchHelper.createBBoxIndex(esClient, bboxIndexAlias, supportedLanguages);
-    var bulkListener = new BulkIndexer(esClient);
     return new ElasticRunContext(esClient, pointsIndexAlias, bboxIndexAlias, targetPointsIndex, targetBBoxIndex,
-        supportedLanguages, qrankLookup, bulkListener);
+        supportedLanguages, qrankLookup, bulkListener, containerIndex);
   }
 
   /**
@@ -222,9 +228,9 @@ public class ElasticsearchHelper {
    * that were built for the live index.
    */
   public static void finalizeRun(ElasticRunContext context) throws Exception {
-    // Drains and logs what was indexed; any drops are logged, not fatal — the
-    // aliases still advance so a build never leaves the previous index live.
     context.bulkListener().close();
+
+    context.esClient().indices().refresh(r -> r.index(context.pointsIndexTarget(), context.bboxIndexTarget()));
 
     SearchTemplates.register(context.esClient(), allLanguages(context.supportedLanguages()));
 

--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -140,10 +140,10 @@ public class ElasticsearchHelper {
                         .text(pt -> pt
                             .analyzer("prefix_index_analyzer")
                             .searchAnalyzer("prefix_search_analyzer")))));
-            m.properties("parentNames." + lang, k -> k
+            m.properties("poiParentNames." + lang, k -> k
                 .text(p -> p.analyzer("universal_analyzer")));
-            m.properties("container." + lang, k -> k.keyword(kw -> kw));
-            m.properties("country." + lang, k -> k.keyword(kw -> kw));
+            m.properties("poiContainer." + lang, k -> k.keyword(kw -> kw));
+            m.properties("poiCountry." + lang, k -> k.keyword(kw -> kw));
           }
           m.properties("location", g -> g.geoPoint(p -> p));
           m.properties("poiProminence", n -> n.float_(f -> f));

--- a/src/main/java/il/org/osm/israelhiking/MainClass.java
+++ b/src/main/java/il/org/osm/israelhiking/MainClass.java
@@ -77,16 +77,16 @@ public class MainClass {
             var qrankPath = args.getString("qrank-path",
                     "Path to qrank.csv.gz for the prominence signal (empty = run without it)", "");
             var qrankLookup = QRankLookup.load(qrankPath.isBlank() ? null : Path.of(qrankPath));
+            String area = args.getString("area", "geofabrik area to download", "israel-and-palestine");
             var containerIndexPath = Path.of(args.getString("container-index-path",
                     "Path to the container index from the previous run; loaded to tag points with their "
                             + "country/place, and rewritten from this run's containers for the next run",
-                    "data/sources/container-index.bin.gz"));
+                    "data/sources/container-index-" + area + ".bin.gz"));
             var containerIndex = ContainerIndex.load(containerIndexPath);
             var context = ElasticsearchHelper.initRun(esClient, bulkListener, pointsIndexAlias, bboxIndexAlias,
                     supportedLanguages, qrankLookup, containerIndex);
             var profile = new PlanetSearchProfile(planetiler.config(), context);
 
-            String area = args.getString("area", "geofabrik area to download", "israel-and-palestine");
             planetiler.setProfile(profile);
             // override this default with osm_path="path/to/data.osm.pbf"
             // Geofabrik has no whole-planet file, so area=planet uses the aws:latest

--- a/src/main/java/il/org/osm/israelhiking/MainClass.java
+++ b/src/main/java/il/org/osm/israelhiking/MainClass.java
@@ -65,21 +65,25 @@ public class MainClass {
             LOGGER.warn("skip-tiles=true: collapsing tile output to z0. The ES search index is "
                     + "built normally; the .pmtiles archive will be a stub. Do NOT use for a build "
                     + "whose map tiles are consumed (client / production map).");
-            // Override only the zoom args (not the whole Arguments) — do not re-broaden this.
+            // Override only the zoom args (not the whole Arguments) — do not re-broaden
+            // this.
             args = Arguments.of("maxzoom", "0", "render_maxzoom", "0").orElse(args);
         }
         Planetiler planetiler = Planetiler.create(args);
 
-        var esClient = ElasticsearchHelper.createElasticsearchClient(esAddress);
-        BulkIndexer bulkListener = null;
-        try {
+        try (var esClient = ElasticsearchHelper.createElasticsearchClient(esAddress);
+                var bulkListener = new BulkIndexer(esClient)) {
             var externalFilePath = args.getString("external-file-path", "External file path", "");
             var qrankPath = args.getString("qrank-path",
                     "Path to qrank.csv.gz for the prominence signal (empty = run without it)", "");
             var qrankLookup = QRankLookup.load(qrankPath.isBlank() ? null : Path.of(qrankPath));
-            var context = ElasticsearchHelper.initRun(esClient, pointsIndexAlias, bboxIndexAlias,
-                    supportedLanguages, qrankLookup);
-            bulkListener = context.bulkListener();
+            var containerIndexPath = Path.of(args.getString("container-index-path",
+                    "Path to the container index from the previous run; loaded to tag points with their "
+                            + "country/place, and rewritten from this run's containers for the next run",
+                    "data/sources/container-index.bin.gz"));
+            var containerIndex = ContainerIndex.load(containerIndexPath);
+            var context = ElasticsearchHelper.initRun(esClient, bulkListener, pointsIndexAlias, bboxIndexAlias,
+                    supportedLanguages, qrankLookup, containerIndex);
             var profile = new PlanetSearchProfile(planetiler.config(), context);
 
             String area = args.getString("area", "geofabrik area to download", "israel-and-palestine");
@@ -95,12 +99,9 @@ public class MainClass {
             planetiler.overwriteOutput(Path.of("data", "target", PlanetSearchProfile.POINTS_LAYER_NAME + ".pmtiles"));
             planetiler.run();
 
+            containerIndex.write(containerIndexPath);
+
             ElasticsearchHelper.finalizeRun(context);
-        } finally {
-            if (bulkListener != null) {
-                bulkListener.close();
-            }
-            esClient.close();
         }
     }
 }

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -3,12 +3,16 @@ package il.org.osm.israelhiking;
 import static com.onthegomap.planetiler.reader.osm.OsmElement.Type.RELATION;
 import static com.onthegomap.planetiler.reader.osm.OsmElement.Type.WAY;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -18,6 +22,7 @@ import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygonal;
 import org.locationtech.jts.geom.util.GeometryFixer;
+import org.locationtech.jts.simplify.TopologyPreservingSimplifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +39,7 @@ import com.onthegomap.planetiler.reader.osm.OsmRelationInfo;
 
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 
+import il.org.osm.israelhiking.ContainerIndex.ContainerRecord;
 import il.org.osm.israelhiking.ElasticsearchHelper.ElasticRunContext;
 
 public class PlanetSearchProfile implements Profile {
@@ -41,6 +47,9 @@ public class PlanetSearchProfile implements Profile {
 
   private PlanetilerConfig config;
   private ElasticRunContext context;
+
+  /** Containment near a border is fuzzy anyway; ~0.0005° ≈ 50 m trims the polygons hard. */
+  private static final double CONTAINER_SIMPLIFY_DEGREES = 0.0005;
 
   public static final String POINTS_LAYER_NAME = "global_points";
 
@@ -675,11 +684,50 @@ public class PlanetSearchProfile implements Profile {
   }
 
   private void insertPointToElasticsearch(PointDocument pointDocument, String docId) {
+    enrichWithContainers(pointDocument);
     this.context.bulkListener().add(BulkOperation.of(op -> op
         .index(idx -> idx
             .index(this.context.pointsIndexTarget())
             .id(docId)
             .document(pointDocument))));
+  }
+
+  /**
+   * Tags the point with the places it falls inside: the union of their names
+   * (for "point, place" search), plus the tightest enclosing place and the
+   * country (for display). Uses the container index loaded from the previous
+   * build, so a first-ever build tags nothing and simply produces the index.
+   */
+  private void enrichWithContainers(PointDocument pointDocument) {
+    if (pointDocument.location == null) {
+      return;
+    }
+    var matches = this.context.containerIndex().containing(pointDocument.location[1], pointDocument.location[0]);
+    if (matches.isEmpty()) {
+      return;
+    }
+    ContainerRecord country = null;
+    ContainerRecord container = null;
+    Map<String, Set<String>> names = new LinkedHashMap<>();
+    for (ContainerRecord match : matches) {
+      match.names.forEach((lang, name) -> names.computeIfAbsent(lang, k -> new LinkedHashSet<>()).add(name));
+      if (match.isCountry()) {
+        if (country == null || match.area < country.area) {
+          country = match;
+        }
+      } else if (container == null || match.area < container.area) {
+        container = match;
+      }
+    }
+    Map<String, List<String>> parentNames = new LinkedHashMap<>();
+    names.forEach((lang, set) -> parentNames.put(lang, new ArrayList<>(set)));
+    pointDocument.parentNames = parentNames;
+    if (country != null) {
+      pointDocument.country = country.names;
+    }
+    if (container != null) {
+      pointDocument.container = container.names;
+    }
   }
 
   private void insertBboxToElasticsearch(SourceFeature feature, String[] supportedLanguages) {
@@ -705,6 +753,7 @@ public class PlanetSearchProfile implements Profile {
       if (feature.hasTag("name")) {
         CoalesceIntoMap(bbox.name, "default", feature.getString("name"));
       }
+      collectContainer(feature, polygon, bbox);
       this.context.bulkListener().add(BulkOperation.of(op -> op
           .index(idx -> idx
               .index(this.context.bboxIndexTarget())
@@ -714,6 +763,25 @@ public class PlanetSearchProfile implements Profile {
       this.context.bulkListener().recordFailure(this.context.bboxIndexTarget());
       LOGGER.warn("Failed to index the bounding box of {}: {}", documentId, e.getMessage());
     }
+  }
+
+  /**
+   * Records a container for the next build to enrich points with: its names,
+   * admin level (for the country vs. local-container split), area (to pick the
+   * tightest), and a simplified polygon for the containment test.
+   */
+  private void collectContainer(SourceFeature feature, Geometry polygon, BBoxDocument bbox) {
+    if (bbox.name.isEmpty()) {
+      return;
+    }
+    int adminLevel = feature.hasTag("admin_level") ? (int) feature.getLong("admin_level") : 0;
+    Geometry simplified;
+    try {
+      simplified = TopologyPreservingSimplifier.simplify(polygon, CONTAINER_SIMPLIFY_DEGREES);
+    } catch (RuntimeException e) {
+      simplified = polygon;
+    }
+    this.context.containerIndex().add(new ContainerRecord(new LinkedHashMap<>(bbox.name), adminLevel, bbox.area, simplified));
   }
 
   /**

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -48,7 +48,10 @@ public class PlanetSearchProfile implements Profile {
   private PlanetilerConfig config;
   private ElasticRunContext context;
 
-  /** Containment near a border is fuzzy anyway; ~0.0005° ≈ 50 m trims the polygons hard. */
+  /**
+   * Containment near a border is fuzzy anyway; ~0.0005° ≈ 50 m trims the polygons
+   * hard.
+   */
   private static final double CONTAINER_SIMPLIFY_DEGREES = 0.0005;
 
   public static final String POINTS_LAYER_NAME = "global_points";
@@ -721,12 +724,12 @@ public class PlanetSearchProfile implements Profile {
     }
     Map<String, List<String>> parentNames = new LinkedHashMap<>();
     names.forEach((lang, set) -> parentNames.put(lang, new ArrayList<>(set)));
-    pointDocument.parentNames = parentNames;
+    pointDocument.poiParentNames = parentNames;
     if (country != null) {
-      pointDocument.country = country.names;
+      pointDocument.poiCountry = country.names;
     }
     if (container != null) {
-      pointDocument.container = container.names;
+      pointDocument.poiContainer = container.names;
     }
   }
 
@@ -781,7 +784,8 @@ public class PlanetSearchProfile implements Profile {
     } catch (RuntimeException e) {
       simplified = polygon;
     }
-    this.context.containerIndex().add(new ContainerRecord(new LinkedHashMap<>(bbox.name), adminLevel, bbox.area, simplified));
+    this.context.containerIndex()
+        .add(new ContainerRecord(new LinkedHashMap<>(bbox.name), adminLevel, bbox.area, simplified));
   }
 
   /**

--- a/src/main/java/il/org/osm/israelhiking/PointDocument.java
+++ b/src/main/java/il/org/osm/israelhiking/PointDocument.java
@@ -11,6 +11,15 @@ class PointDocument {
   public Map<String, String> name = new HashMap<String, String>();
   public Map<String, List<String>> alt_names;
   public Map<String, String> description = new HashMap<String, String>();
+  /**
+   * Names of every place this point falls inside, per language, for "point,
+   * place" search.
+   */
+  public Map<String, List<String>> poiParentNames;
+  /** The tightest enclosing place, per language, for display. */
+  public Map<String, String> poiContainer;
+  /** The enclosing country, per language, for display. */
+  public Map<String, String> poiCountry;
   public String wikidata;
   public String image;
   public String wikimedia_commons;
@@ -28,10 +37,5 @@ class PointDocument {
   public Boolean intermittent;
   public Integer population;
   public String poiFeatureClass;
-  /** Names of every place this point falls inside, per language, for "point, place" search. */
-  public Map<String, List<String>> parentNames;
-  /** The tightest enclosing place, per language, for display. */
-  public Map<String, String> container;
-  /** The enclosing country, per language, for display. */
-  public Map<String, String> country;
+
 }

--- a/src/main/java/il/org/osm/israelhiking/PointDocument.java
+++ b/src/main/java/il/org/osm/israelhiking/PointDocument.java
@@ -28,4 +28,10 @@ class PointDocument {
   public Boolean intermittent;
   public Integer population;
   public String poiFeatureClass;
+  /** Names of every place this point falls inside, per language, for "point, place" search. */
+  public Map<String, List<String>> parentNames;
+  /** The tightest enclosing place, per language, for display. */
+  public Map<String, String> container;
+  /** The enclosing country, per language, for display. */
+  public Map<String, String> country;
 }

--- a/src/main/java/il/org/osm/israelhiking/SearchTemplates.java
+++ b/src/main/java/il/org/osm/israelhiking/SearchTemplates.java
@@ -38,7 +38,7 @@ public final class SearchTemplates {
   /** The parameters each template accepts, published in the search contract. */
   public static final Map<String, List<String>> PARAMETERS = Map.of(
       POINTS_SEARCH, List.of("searchTerm", "prefix", "hasCenter", "lat", "lng", "zoom",
-          "hasPlaceShape", "placeShape"),
+          "hasPlaceShape", "placeShape", "place"),
       POINTS_SEARCH_EXACT, List.of("searchTerm"),
       BBOX_CONTAINER, List.of("place", "prefix"),
       BBOX_CONTAINS, List.of("shape"));

--- a/src/main/resources/search-templates/points_search.json
+++ b/src/main/resources/search-templates/points_search.json
@@ -159,9 +159,9 @@
             ]
           }
         }
-      ]
-      {{#hasPlaceShape}}
-      ,"filter": [
+      ],
+      "filter": [
+        {{#hasPlaceShape}}
         {
           "geo_shape": {
             "location": {
@@ -170,8 +170,18 @@
             }
           }
         }
+        {{/hasPlaceShape}}
+        {{#place}}
+        {{#hasPlaceShape}},{{/hasPlaceShape}}
+        {
+          "multi_match": {
+            "type": "phrase",
+            "query": "{{place}}",
+            "fields": [[[#languages]]"poiParentNames.[[lang]]"[[/languages]]]
+          }
+        }
+        {{/place}}
       ]
-      {{/hasPlaceShape}}
     }
   }
 }

--- a/src/test/java/il/org/osm/israelhiking/E2ETest.java
+++ b/src/test/java/il/org/osm/israelhiking/E2ETest.java
@@ -2,10 +2,18 @@ package il.org.osm.israelhiking;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -28,21 +36,122 @@ import il.org.osm.israelhiking.SearchCases.Hit;
 @Tag("e2e")
 public class E2ETest {
 
+    private static final Logger LOGGER = Logger.getLogger(E2ETest.class.getName());
+
     private static final String EXTERNAL_FILE = "./src/test/resources/external.geojson";
     private static final String POINTS_ALIAS = "points";
     private static final String BBOX_ALIAS = "bbox";
 
+    private static final String ES_ADDRESS = "http://localhost:9200";
+
+    // What this test runs on. The values below are the ones the CI runs, change
+    // them here to score the queries against another part of the world, for
+    // example North America, where most of the relevance cases are:
+    //
+    // AREA = "north-america" - an 18 GB extract, needs a bigger heap, i.e.
+    // -DargLine="-Xmx24g", and takes a couple of hours
+    // SEARCH_CASES = "/search-relevance-cases.json" - the 305 relevance cases
+    // CONTAINER_CASES = "" - the container cases are Israeli, so skip them
+    // USE_QRANK = true - prominence is only realistic with QRank, the file is
+    // downloaded once into data/sources and reused
+    private static final String AREA = "israel-and-palestine";
+    private static final String SEARCH_CASES = "/search-sanity-cases.json";
+    private static final String CONTAINER_CASES = "/search-container-cases.json";
+    private static final boolean USE_QRANK = false;
+
+    /** Downloaded on demand, next to the OSM extract planetiler downloads. */
+    private static final Path QRANK_FILE = Path.of("data", "sources", "qrank.csv.gz");
+    private static final String QRANK_URL = "https://qrank.toolforge.org/download/qrank.csv.gz";
+
+    /**
+     * Written by the first build and loaded by the second to tag points with their
+     * containers.
+     */
+    private static final Path CONTAINER_INDEX = Path.of("data", "sources", "e2e-container-index.bin.gz");
+
     @Test
     public void test() throws Exception {
-        var esAddress = System.getProperty("es.address", "http://localhost:9200");
-
-        MainClass.main(new String[] { "--download", "--external-file-path", EXTERNAL_FILE,
-                "--es-address", esAddress });
-
-        try (var esClient = ElasticsearchHelper.createElasticsearchClient(esAddress)) {
-            assertEveryCaseIsFound(esClient);
-            assertEveryPointHasAContainer(esClient);
+        var arguments = new ArrayList<String>(List.of("--download",
+                "--area", AREA,
+                "--external-file-path", EXTERNAL_FILE,
+                "--es-address", ES_ADDRESS,
+                "--container-index-path", CONTAINER_INDEX.toString()));
+        if (USE_QRANK) {
+            arguments.add("--qrank-path");
+            arguments.add(downloadQrankIfMissing().toString());
         }
+
+        MainClass.main(arguments.toArray(String[]::new));
+        MainClass.main(arguments.toArray(String[]::new));
+
+        try (var esClient = ElasticsearchHelper.createElasticsearchClient(ES_ADDRESS)) {
+            assertEveryCaseIsFound(esClient, SEARCH_CASES);
+            if (!CONTAINER_CASES.isBlank()) {
+                assertEveryPointHasAContainer(esClient, CONTAINER_CASES);
+            }
+            assertPointsAreEnrichedWithContainers(esClient);
+        }
+    }
+
+    /**
+     * The second build tags every point with the places that contain it. Points
+     * for cities deep inside the country must come back with their containers,
+     * which proves the enrichment ran and did not break indexing.
+     */
+    private void assertPointsAreEnrichedWithContainers(ElasticsearchClient esClient) throws Exception {
+        var terms = List.of("חיפה", "תל אביב", "ירושלים");
+        var failures = new ArrayList<String>();
+        for (var term : terms) {
+            var point = topPoint(esClient, term);
+            if (point == null) {
+                failures.add("  " + term + ": no hit at all");
+            } else if (point.parentNames == null || point.parentNames.isEmpty()) {
+                failures.add("  " + term + ": no containers attached (parentNames=" + point.parentNames
+                        + ", container=" + point.container + ", country=" + point.country + ")");
+            }
+        }
+        if (!failures.isEmpty()) {
+            fail(failures.size() + " of " + terms.size() + " points were not enriched with containers:\n"
+                    + String.join("\n", failures));
+        }
+    }
+
+    private PointDocument topPoint(ElasticsearchClient esClient, String term) throws Exception {
+        var response = esClient.searchTemplate(s -> s
+                .index(POINTS_ALIAS)
+                .id(SearchTemplates.POINTS_SEARCH)
+                .params(Map.of("searchTerm", JsonData.of(term))),
+                PointDocument.class);
+        var hits = response.hits().hits();
+        return hits.isEmpty() ? null : hits.get(0).source();
+    }
+
+    /**
+     * The prominence of a point depends on QRank, so scoring the queries against
+     * an index that was built without it is scoring against a different world.
+     * The file is ~360 MB, so it is downloaded once, next to the OSM extract, and
+     * reused by every later run.
+     */
+    private Path downloadQrankIfMissing() throws Exception {
+        if (Files.exists(QRANK_FILE) && Files.size(QRANK_FILE) > 0) {
+            LOGGER.info("Using the QRank file that is already there: " + QRANK_FILE);
+            return QRANK_FILE;
+        }
+        LOGGER.info("Downloading QRank from " + QRANK_URL + ", this takes a while");
+        Files.createDirectories(QRANK_FILE.getParent());
+        var partial = QRANK_FILE.resolveSibling("qrank.csv.gz.partial");
+        try (var http = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build()) {
+            var request = HttpRequest.newBuilder(URI.create(QRANK_URL)).GET().build();
+            var response = http.send(request, HttpResponse.BodyHandlers.ofFile(partial));
+            if (response.statusCode() != 200) {
+                Files.deleteIfExists(partial);
+                throw new IllegalStateException("Failed to download QRank, got HTTP " + response.statusCode());
+            }
+        }
+        // Only name it once it is whole, so that a broken download is not reused.
+        Files.move(partial, QRANK_FILE, StandardCopyOption.REPLACE_EXISTING);
+        LOGGER.info("Downloaded QRank to " + QRANK_FILE + " (" + Files.size(QRANK_FILE) / 1024 / 1024 + " MB)");
+        return QRANK_FILE;
     }
 
     /**
@@ -50,10 +159,10 @@ public class E2ETest {
      * that place is a self intersecting one, which Elasticsearch refuses to
      * index as is.
      */
-    private void assertEveryPointHasAContainer(ElasticsearchClient esClient) throws Exception {
+    private void assertEveryPointHasAContainer(ElasticsearchClient esClient, String casesResource) throws Exception {
         var mapper = new ObjectMapper();
         List<ContainerCase> cases = mapper.readValue(
-                getClass().getResourceAsStream("/search-container-cases.json"),
+                getClass().getResourceAsStream(casesResource),
                 mapper.getTypeFactory().constructCollectionType(List.class, ContainerCase.class));
         var failures = new ArrayList<String>();
         for (var containerCase : cases) {
@@ -87,8 +196,8 @@ public class E2ETest {
      * Searches the index that was just built, and fails with all the cases that
      * did not find what they were looking for, not only the first one.
      */
-    private void assertEveryCaseIsFound(ElasticsearchClient esClient) throws Exception {
-        var cases = SearchCases.load("/search-sanity-cases.json");
+    private void assertEveryCaseIsFound(ElasticsearchClient esClient, String casesResource) throws Exception {
+        var cases = SearchCases.load(casesResource);
         var failures = new ArrayList<String>();
         for (var searchCase : cases) {
             var failure = SearchCases.failure(searchCase, search(esClient, searchCase));

--- a/src/test/java/il/org/osm/israelhiking/E2ETest.java
+++ b/src/test/java/il/org/osm/israelhiking/E2ETest.java
@@ -63,19 +63,12 @@ public class E2ETest {
     private static final Path QRANK_FILE = Path.of("data", "sources", "qrank.csv.gz");
     private static final String QRANK_URL = "https://qrank.toolforge.org/download/qrank.csv.gz";
 
-    /**
-     * Written by the first build and loaded by the second to tag points with their
-     * containers.
-     */
-    private static final Path CONTAINER_INDEX = Path.of("data", "sources", "e2e-container-index.bin.gz");
-
     @Test
     public void test() throws Exception {
         var arguments = new ArrayList<String>(List.of("--download",
                 "--area", AREA,
                 "--external-file-path", EXTERNAL_FILE,
-                "--es-address", ES_ADDRESS,
-                "--container-index-path", CONTAINER_INDEX.toString()));
+                "--es-address", ES_ADDRESS));
         if (USE_QRANK) {
             arguments.add("--qrank-path");
             arguments.add(downloadQrankIfMissing().toString());
@@ -90,6 +83,7 @@ public class E2ETest {
                 assertEveryPointHasAContainer(esClient, CONTAINER_CASES);
             }
             assertPointsAreEnrichedWithContainers(esClient);
+            assertPlaceFilterScopesToContainers(esClient);
         }
     }
 
@@ -116,14 +110,53 @@ public class E2ETest {
         }
     }
 
+    /**
+     * The {@code place} parameter scopes a search to points whose containers
+     * include that place — the single query behind a "point, place" search. A
+     * point must survive a filter on one of its own containers and be dropped by
+     * a filter on a place that contains nothing.
+     */
+    private void assertPlaceFilterScopesToContainers(ElasticsearchClient esClient) throws Exception {
+        var term = "חיפה";
+        var unscoped = searchPoints(esClient, Map.of("searchTerm", JsonData.of(term)));
+        if (unscoped.isEmpty() || unscoped.get(0).poiParentNames == null
+                || unscoped.get(0).poiParentNames.isEmpty()) {
+            fail("cannot check the place filter: \"" + term + "\" returned no enriched point");
+        }
+        var container = unscoped.get(0).poiParentNames.values().stream()
+                .flatMap(List::stream).findFirst().orElseThrow();
+
+        var scopedToContainer = searchPoints(esClient,
+                Map.of("searchTerm", JsonData.of(term), "place", JsonData.of(container)));
+        var scopedToNowhere = searchPoints(esClient,
+                Map.of("searchTerm", JsonData.of(term), "place", JsonData.of("לא-מקום-שקיים")));
+
+        var failures = new ArrayList<String>();
+        if (scopedToContainer.isEmpty()) {
+            failures.add("  place=\"" + container + "\" (a real container of " + term + ") returned nothing");
+        }
+        if (!scopedToNowhere.isEmpty()) {
+            failures.add("  place=\"לא-מקום-שקיים\" (contains nothing) still returned "
+                    + scopedToNowhere.size() + " hit(s)");
+        }
+        if (!failures.isEmpty()) {
+            fail("the place filter did not scope the search:\n" + String.join("\n", failures));
+        }
+    }
+
     private PointDocument topPoint(ElasticsearchClient esClient, String term) throws Exception {
+        var hits = searchPoints(esClient, Map.of("searchTerm", JsonData.of(term)));
+        return hits.isEmpty() ? null : hits.get(0);
+    }
+
+    private List<PointDocument> searchPoints(ElasticsearchClient esClient, Map<String, JsonData> params)
+            throws Exception {
         var response = esClient.searchTemplate(s -> s
                 .index(POINTS_ALIAS)
                 .id(SearchTemplates.POINTS_SEARCH)
-                .params(Map.of("searchTerm", JsonData.of(term))),
+                .params(params),
                 PointDocument.class);
-        var hits = response.hits().hits();
-        return hits.isEmpty() ? null : hits.get(0).source();
+        return response.hits().hits().stream().map(hit -> hit.source()).toList();
     }
 
     /**

--- a/src/test/java/il/org/osm/israelhiking/E2ETest.java
+++ b/src/test/java/il/org/osm/israelhiking/E2ETest.java
@@ -105,9 +105,9 @@ public class E2ETest {
             var point = topPoint(esClient, term);
             if (point == null) {
                 failures.add("  " + term + ": no hit at all");
-            } else if (point.parentNames == null || point.parentNames.isEmpty()) {
-                failures.add("  " + term + ": no containers attached (parentNames=" + point.parentNames
-                        + ", container=" + point.container + ", country=" + point.country + ")");
+            } else if (point.poiParentNames == null || point.poiParentNames.isEmpty()) {
+                failures.add("  " + term + ": no containers attached (parentNames=" + point.poiParentNames
+                        + ", container=" + point.poiContainer + ", country=" + point.poiCountry + ")");
             }
         }
         if (!failures.isEmpty()) {


### PR DESCRIPTION
This will allow removing the need for an extra query for container name, and in general will remove the need for the bbox index.
This is the first phase of only adding the relevant data and updating the query.
It works in a way that the first ever run will not have a places indexes etc, but will write the container index, later on the next run will pick it up.
If this design will be problematic I'll think of a way to improve it...
- Resolves #65