### PR TITLE
Move containers to use the bbox index instead of the file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Additional arguments to this wrapper besides the Planetiler's arguments:
 | `external-file-path` | External geojson file path to allow adding non OSM features to the search and POIs. these features should have a specific format | "empty" |
 | `skip-tiles` | Collapse the tile pyramid to z0 so the `.pmtiles` archive is a near-instant stub, to speed up an Elasticsearch-only reindex. The search index is built identically; only the map tiles degrade, so do not use it for a build whose map tiles are consumed. | `false` |
 | `qrank-path` | Path to a gzipped `qrank.csv.gz` used to compute the `poiProminence` ranking signal. Optional — leave empty to build without it (every point still gets a base+metadata prominence; only the QRank signal is omitted). | "empty" |
-| `container-index-path` | Path to the container index the previous build wrote; it is loaded to tag every point with the places that contain it, and rewritten from this build's containers for the next build. Defaulted per `area`, since each area has its own containers. See [Containers on points](#containers-on-points). | `data/sources/container-index-<area>.bin.gz` |
 | `update-templates-only` | Store the search templates of this build in Elasticsearch and exit, without building anything. Updates the queries of a live index without a reindex | `false` |
 
 The QRank data file comes from [https://qrank.toolforge.org](https://qrank.toolforge.org) (CC0): a gzipped CSV (`Entity,QRank`) ranking Wikidata entities by aggregated Wikimedia pageviews. `qrank-path` is optional and fully omittable — omit it and the build runs unchanged without the ~363 MB file.
@@ -89,9 +88,9 @@ Every point is tagged at build time with the places that contain it, so a "point
 - `poiContainer` — the tightest place around it, for display.
 - `poiCountry` — the country, for display, shown next to the container when they differ.
 
-Point-in-polygon can't run in the single streaming pass, because a point is read before the boundary that contains it is assembled. So containers are carried between builds: a build collects its containers — admin boundaries up to level 8, settlements, parks and reserves — into `container-index-path`, and the next build loads that file into an in-memory spatial index and tags its points from it. Containers change rarely, so the one-build lag is by design.
+Point-in-polygon can't run in the single streaming pass, because a point is read before the boundary that contains it is assembled. So containers are carried between builds through the bbox index — the same documents used to answer `bbox_contains`, no separate store: at the start of a build the live `bbox` alias still points at the previous build's containers, so the build loads them (admin boundaries up to level 8, settlements, parks and reserves) into an in-memory spatial index and tags its points from them, before swapping in its own bbox index at the end. Containers change rarely, so the one-build lag is by design.
 
-The catch is that a fresh deployment needs **two build cycles** to fully populate: the first writes the container index while its own points go untagged, and the second tags its points from that file. The end to end test exercises this by building twice.
+The catch is that a fresh deployment needs **two build cycles** to fully populate: the first build has no previous bbox index to load, so its points go untagged, and the second tags its points from the first's containers. The end to end test exercises this by building twice.
 
 ## External features file format
 

--- a/src/main/java/il/org/osm/israelhiking/BBoxDocument.java
+++ b/src/main/java/il/org/osm/israelhiking/BBoxDocument.java
@@ -6,17 +6,22 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Polygon;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class BBoxDocument {
     public Map<String, String> name = new HashMap<String, String>();
     public Map<String, Object> bbox;
     public double area;
     public double[] center;
+    /** OSM admin_level (2 = country, 0 when not an admin boundary); read back to enrich points. */
+    public int adminLevel;
 
     public void setBBox(Geometry geometry) {
         bbox = new HashMap<String, Object>();

--- a/src/main/java/il/org/osm/israelhiking/ContainerIndex.java
+++ b/src/main/java/il/org/osm/israelhiking/ContainerIndex.java
@@ -1,50 +1,48 @@
 package il.org.osm.israelhiking;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 import org.locationtech.jts.index.strtree.STRtree;
-import org.locationtech.jts.io.ParseException;
-import org.locationtech.jts.io.WKBReader;
-import org.locationtech.jts.io.WKBWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+
 /**
- * The container side of a build, both halves in one object: it {@link #load}s
- * the previous build's containers into a queryable spatial index (used by
- * {@link #containing} to tag each point), and {@link #add}s the containers this
- * build sees so {@link #write} can persist them for the next build. Containers
- * change rarely, so the one-build lag is acceptable.
+ * An in-memory spatial index of container polygons, queried point-by-point to
+ * find the places that enclose each POI. Built once (single-threaded) and then
+ * queried concurrently from the Planetiler worker threads — {@link STRtree}
+ * queries and {@link PreparedGeometry#contains} are both thread-safe once the
+ * tree has been built.
  *
- * <p>Built once (single-threaded), then both queried and appended concurrently
- * from the Planetiler worker threads: {@link STRtree} queries and
- * {@link PreparedGeometry#contains} are thread-safe once the tree is built, and
- * the append side is a {@link ConcurrentLinkedQueue}.
+ * <p>The containers are the same documents the build writes to the bbox index,
+ * so there is no separate store: a build {@link #load}s them from the live bbox
+ * alias, which — until this build swaps its own bbox index in at the end — still
+ * points at the previous build's containers. Containers change rarely, so that
+ * one-build lag is by design; a first-ever build finds no alias and tags nothing.
  */
 final class ContainerIndex {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ContainerIndex.class);
   private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
+
+  private static final String SCROLL_KEEPALIVE = "2m";
+  private static final int SCROLL_SIZE = 2000;
 
   /**
    * A place a point can fall inside — an admin boundary, a settlement polygon, a
@@ -79,31 +77,25 @@ final class ContainerIndex {
 
   private final STRtree tree = new STRtree();
   private final int loadedCount;
-  private final Collection<ContainerRecord> collected = new ConcurrentLinkedQueue<>();
 
-  private ContainerIndex(Collection<ContainerRecord> loaded) {
-    for (ContainerRecord record : loaded) {
+  private ContainerIndex(Collection<ContainerRecord> records) {
+    for (ContainerRecord record : records) {
       tree.insert(record.geometry.getEnvelopeInternal(),
           new Entry(record, PreparedGeometryFactory.prepare(record.geometry)));
     }
     tree.build();
-    this.loadedCount = loaded.size();
+    this.loadedCount = records.size();
   }
 
-  /** Loads the previous build's containers for lookup; a missing file yields an empty index. */
-  static ContainerIndex load(Path path) throws IOException {
-    if (path == null || !Files.exists(path)) {
-      LOGGER.info("Container index: none at {} — this build tags no points and will produce it", path);
+  /** Loads the previous build's containers from the bbox alias; no alias yet yields an empty index. */
+  static ContainerIndex load(ElasticsearchClient esClient, String bboxAlias) throws IOException {
+    if (!esClient.indices().existsAlias(a -> a.name(bboxAlias)).value()) {
+      LOGGER.info("Container index: no '{}' index yet — this build tags no points", bboxAlias);
       return new ContainerIndex(List.of());
     }
-    List<ContainerRecord> records = read(path);
-    LOGGER.info("Container index: loaded {} containers from {}", records.size(), path);
+    List<ContainerRecord> records = scroll(esClient, bboxAlias);
+    LOGGER.info("Container index: loaded {} containers from '{}'", records.size(), bboxAlias);
     return new ContainerIndex(records);
-  }
-
-  /** Remembers a container seen in this build, to be persisted by {@link #write}. */
-  void add(ContainerRecord record) {
-    collected.add(record);
   }
 
   /** The containers that enclose the given coordinate, in no particular order. */
@@ -122,54 +114,93 @@ final class ContainerIndex {
     return hits;
   }
 
-  /** Persists the containers collected in this build for the next build to load. */
-  void write(Path path) throws IOException {
-    List<ContainerRecord> snapshot = new ArrayList<>(collected);
-    WKBWriter wkbWriter = new WKBWriter();
-    try (DataOutputStream out = new DataOutputStream(
-        new BufferedOutputStream(new GZIPOutputStream(Files.newOutputStream(path))))) {
-      out.writeInt(snapshot.size());
-      for (ContainerRecord record : snapshot) {
-        byte[] wkb = wkbWriter.write(record.geometry);
-        out.writeInt(wkb.length);
-        out.write(wkb);
-        out.writeInt(record.adminLevel);
-        out.writeDouble(record.area);
-        out.writeInt(record.names.size());
-        for (Map.Entry<String, String> name : record.names.entrySet()) {
-          out.writeUTF(name.getKey());
-          out.writeUTF(name.getValue());
-        }
-      }
-    }
-    LOGGER.info("Container index: wrote {} containers to {}", snapshot.size(), path);
-  }
-
-  private static List<ContainerRecord> read(Path path) throws IOException {
-    WKBReader wkbReader = new WKBReader(GEOMETRY_FACTORY);
+  private static List<ContainerRecord> scroll(ElasticsearchClient esClient, String bboxAlias) throws IOException {
     List<ContainerRecord> records = new ArrayList<>();
-    try (DataInputStream in = new DataInputStream(
-        new BufferedInputStream(new GZIPInputStream(Files.newInputStream(path))))) {
-      int count = in.readInt();
-      for (int i = 0; i < count; i++) {
-        byte[] wkb = new byte[in.readInt()];
-        in.readFully(wkb);
-        Geometry geometry;
-        try {
-          geometry = wkbReader.read(wkb);
-        } catch (ParseException e) {
-          throw new IOException("corrupt container geometry at record " + i, e);
+    var response = esClient.search(s -> s
+        .index(bboxAlias)
+        .scroll(t -> t.time(SCROLL_KEEPALIVE))
+        .size(SCROLL_SIZE)
+        .query(q -> q.matchAll(m -> m)), JsonNode.class);
+    String scrollId = response.scrollId();
+    try {
+      var hits = response.hits().hits();
+      while (!hits.isEmpty()) {
+        for (var hit : hits) {
+          ContainerRecord record = toRecord(hit.source());
+          if (record != null) {
+            records.add(record);
+          }
         }
-        int adminLevel = in.readInt();
-        double area = in.readDouble();
-        int nameCount = in.readInt();
-        Map<String, String> names = new LinkedHashMap<>(nameCount);
-        for (int n = 0; n < nameCount; n++) {
-          names.put(in.readUTF(), in.readUTF());
-        }
-        records.add(new ContainerRecord(names, adminLevel, area, geometry));
+        final String currentScrollId = scrollId;
+        var scrollResponse = esClient.scroll(
+            sc -> sc.scrollId(currentScrollId).scroll(t -> t.time(SCROLL_KEEPALIVE)), JsonNode.class);
+        scrollId = scrollResponse.scrollId();
+        hits = scrollResponse.hits().hits();
       }
+    } finally {
+      final String finalScrollId = scrollId;
+      esClient.clearScroll(c -> c.scrollId(finalScrollId));
     }
     return records;
+  }
+
+  private static ContainerRecord toRecord(JsonNode source) {
+    if (source == null) {
+      return null;
+    }
+    JsonNode bbox = source.path("bbox");
+    JsonNode nameNode = source.path("name");
+    if (bbox.isMissingNode() || !nameNode.isObject() || nameNode.isEmpty()) {
+      return null;
+    }
+    Map<String, String> names = new LinkedHashMap<>();
+    nameNode.properties().forEach(field -> names.put(field.getKey(), field.getValue().asText()));
+    try {
+      Geometry geometry = geometryFromGeoJson(bbox);
+      if (geometry == null || geometry.isEmpty()) {
+        return null;
+      }
+      return new ContainerRecord(names, source.path("adminLevel").asInt(0), source.path("area").asDouble(0), geometry);
+    } catch (RuntimeException e) {
+      LOGGER.warn("Skipping a container with unreadable geometry: {}", e.getMessage());
+      return null;
+    }
+  }
+
+  private static Geometry geometryFromGeoJson(JsonNode geoJson) {
+    String type = geoJson.path("type").asText();
+    JsonNode coordinates = geoJson.path("coordinates");
+    if (!coordinates.isArray()) {
+      return null;
+    }
+    if ("polygon".equals(type)) {
+      return polygon(coordinates);
+    }
+    if ("multipolygon".equals(type)) {
+      Polygon[] polygons = new Polygon[coordinates.size()];
+      for (int i = 0; i < coordinates.size(); i++) {
+        polygons[i] = polygon(coordinates.get(i));
+      }
+      return GEOMETRY_FACTORY.createMultiPolygon(polygons);
+    }
+    return null;
+  }
+
+  private static Polygon polygon(JsonNode rings) {
+    LinearRing shell = ring(rings.get(0));
+    LinearRing[] holes = new LinearRing[rings.size() - 1];
+    for (int i = 1; i < rings.size(); i++) {
+      holes[i - 1] = ring(rings.get(i));
+    }
+    return GEOMETRY_FACTORY.createPolygon(shell, holes);
+  }
+
+  private static LinearRing ring(JsonNode coordinates) {
+    Coordinate[] points = new Coordinate[coordinates.size()];
+    for (int i = 0; i < coordinates.size(); i++) {
+      JsonNode point = coordinates.get(i);
+      points[i] = new Coordinate(point.get(0).asDouble(), point.get(1).asDouble());
+    }
+    return GEOMETRY_FACTORY.createLinearRing(points);
   }
 }

--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -179,6 +179,7 @@ public class ElasticsearchHelper {
           m.properties("bbox", g -> g.geoShape(p -> p));
           m.properties("area", n -> n.float_(f -> f));
           m.properties("center", g -> g.geoPoint(p -> p));
+          m.properties("adminLevel", n -> n.integer(f -> f));
           return m;
         }));
 

--- a/src/main/java/il/org/osm/israelhiking/MainClass.java
+++ b/src/main/java/il/org/osm/israelhiking/MainClass.java
@@ -78,11 +78,7 @@ public class MainClass {
                     "Path to qrank.csv.gz for the prominence signal (empty = run without it)", "");
             var qrankLookup = QRankLookup.load(qrankPath.isBlank() ? null : Path.of(qrankPath));
             String area = args.getString("area", "geofabrik area to download", "israel-and-palestine");
-            var containerIndexPath = Path.of(args.getString("container-index-path",
-                    "Path to the container index from the previous run; loaded to tag points with their "
-                            + "country/place, and rewritten from this run's containers for the next run",
-                    "data/sources/container-index-" + area + ".bin.gz"));
-            var containerIndex = ContainerIndex.load(containerIndexPath);
+            var containerIndex = ContainerIndex.load(esClient, bboxIndexAlias);
             var context = ElasticsearchHelper.initRun(esClient, bulkListener, pointsIndexAlias, bboxIndexAlias,
                     supportedLanguages, qrankLookup, containerIndex);
             var profile = new PlanetSearchProfile(planetiler.config(), context);
@@ -98,8 +94,6 @@ public class MainClass {
             }
             planetiler.overwriteOutput(Path.of("data", "target", PlanetSearchProfile.POINTS_LAYER_NAME + ".pmtiles"));
             planetiler.run();
-
-            containerIndex.write(containerIndexPath);
 
             ElasticsearchHelper.finalizeRun(context);
         }

--- a/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
+++ b/src/main/java/il/org/osm/israelhiking/PlanetSearchProfile.java
@@ -718,7 +718,7 @@ public class PlanetSearchProfile implements Profile {
         if (country == null || match.area < country.area) {
           country = match;
         }
-      } else if (container == null || match.area < container.area) {
+      } else if (!sharesName(pointDocument, match) && (container == null || match.area < container.area)) {
         container = match;
       }
     }
@@ -733,6 +733,21 @@ public class PlanetSearchProfile implements Profile {
     }
   }
 
+  /**
+   * Whether the container carries the same name as the point in any shared
+   * language.
+   * A place node commonly sits in a polygon of the same name; using it as
+   * the container would display "X, X", so skip it and let a wider place win.
+   */
+  private static boolean sharesName(PointDocument pointDocument, ContainerRecord container) {
+    for (var entry : pointDocument.name.entrySet()) {
+      if (entry.getValue().equals(container.names.get(entry.getKey()))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private void insertBboxToElasticsearch(SourceFeature feature, String[] supportedLanguages) {
     var documentId = sourceFeatureToDocumentId(feature);
     Geometry polygon;
@@ -744,19 +759,20 @@ public class PlanetSearchProfile implements Profile {
     if (polygon == null) {
       return;
     }
+    Geometry simplified = simplifyContainer(polygon);
     try {
       var bbox = new BBoxDocument();
       bbox.area = feature.areaMeters();
+      bbox.adminLevel = feature.hasTag("admin_level") ? (int) feature.getLong("admin_level") : 0;
       var lngLatCenterPoint = GeoUtils.worldToLatLonCoords(feature.centroid()).getCoordinate();
       bbox.center = new double[] { lngLatCenterPoint.getX(), lngLatCenterPoint.getY() };
-      bbox.setBBox(polygon);
+      bbox.setBBox(simplified);
       for (String lang : supportedLanguages) {
         CoalesceIntoMap(bbox.name, lang, feature.getString("name:" + lang));
       }
       if (feature.hasTag("name")) {
         CoalesceIntoMap(bbox.name, "default", feature.getString("name"));
       }
-      collectContainer(feature, polygon, bbox);
       this.context.bulkListener().add(BulkOperation.of(op -> op
           .index(idx -> idx
               .index(this.context.bboxIndexTarget())
@@ -769,23 +785,15 @@ public class PlanetSearchProfile implements Profile {
   }
 
   /**
-   * Records a container for the next build to enrich points with: its names,
-   * admin level (for the country vs. local-container split), area (to pick the
-   * tightest), and a simplified polygon for the containment test.
+   * Containment near a border is fuzzy anyway; simplifying keeps geometry cheap
+   * to read and write.
    */
-  private void collectContainer(SourceFeature feature, Geometry polygon, BBoxDocument bbox) {
-    if (bbox.name.isEmpty()) {
-      return;
-    }
-    int adminLevel = feature.hasTag("admin_level") ? (int) feature.getLong("admin_level") : 0;
-    Geometry simplified;
+  private static Geometry simplifyContainer(Geometry polygon) {
     try {
-      simplified = TopologyPreservingSimplifier.simplify(polygon, CONTAINER_SIMPLIFY_DEGREES);
+      return TopologyPreservingSimplifier.simplify(polygon, CONTAINER_SIMPLIFY_DEGREES);
     } catch (RuntimeException e) {
-      simplified = polygon;
+      return polygon;
     }
-    this.context.containerIndex()
-        .add(new ContainerRecord(new LinkedHashMap<>(bbox.name), adminLevel, bbox.area, simplified));
   }
 
   /**


### PR DESCRIPTION
Keep bbox index for other usages and also avoid the need to read and write a file.
If we decide to remove bbox index in the future this code could be reverted if needed.