### PR TITLE
Fold latin apostrophes in analyzers; raise exact-name bonus to 0.8

### DIFF
--- a/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
+++ b/src/main/java/il/org/osm/israelhiking/ElasticsearchHelper.java
@@ -24,7 +24,9 @@ public class ElasticsearchHelper {
   static final String HEBREW_DOUBLED_VAV_PATTERN = "\\u05D5\\u05D5";
   static final String HEBREW_DOUBLED_YOD_PATTERN = "\\u05D9\\u05D9";
   static final String NIQQUD_PATTERN = "[\\u05B0-\\u05C7]";
-  static final List<String> HEBREW_CHAR_FILTERS = List.of("hebrew_niqqud", "hebrew_matres_vav", "hebrew_matres_yod");
+  static final String APOSTROPHES_PATTERN = "[\\u0027\\u2018\\u2019\\u02BC]";
+  static final List<String> COMMON_CHAR_FILTERS = List.of("hebrew_niqqud", "hebrew_matres_vav",
+      "hebrew_matres_yod", "latin_apostrophes");
 
   public static record ElasticRunContext(
       ElasticsearchClient esClient,
@@ -84,13 +86,18 @@ public class ElasticsearchHelper {
                 .patternReplace(pr -> pr
                     .pattern(HEBREW_DOUBLED_YOD_PATTERN)
                     .replacement(HEBREW_YOD))))
+        .charFilter("latin_apostrophes", cf -> cf
+            .definition(d -> d
+                .patternReplace(pr -> pr
+                    .pattern(APOSTROPHES_PATTERN)
+                    .replacement(""))))
         .normalizer("universal_normalizer", n -> n
             .custom(cn -> cn
-                .charFilter(HEBREW_CHAR_FILTERS)
+                .charFilter(COMMON_CHAR_FILTERS)
                 .filter("asciifolding", "lowercase")))
         .analyzer("universal_analyzer", an -> an
             .custom(ca -> ca
-                .charFilter(HEBREW_CHAR_FILTERS)
+                .charFilter(COMMON_CHAR_FILTERS)
                 .tokenizer("standard")
                 .filter("asciifolding", "lowercase")));
   }
@@ -110,12 +117,12 @@ public class ElasticsearchHelper {
                         .edgeNgram(en -> en.minGram(2).maxGram(15))))
                 .analyzer("prefix_index_analyzer", an -> an
                     .custom(ca -> ca
-                        .charFilter(HEBREW_CHAR_FILTERS)
+                        .charFilter(COMMON_CHAR_FILTERS)
                         .tokenizer("standard")
                         .filter("asciifolding", "lowercase", "edge_ngram_2_15")))
                 .analyzer("prefix_search_analyzer", an -> an
                     .custom(ca -> ca
-                        .charFilter(HEBREW_CHAR_FILTERS)
+                        .charFilter(COMMON_CHAR_FILTERS)
                         .tokenizer("standard")
                         .filter("asciifolding", "lowercase")))))
         .mappings(m -> {

--- a/src/main/resources/search-templates/points_search.json
+++ b/src/main/resources/search-templates/points_search.json
@@ -126,7 +126,7 @@
                     ]
                   }
                 },
-                "weight": 0.5
+                "weight": 0.8
               }
               {{#hasCenter}}
               ,{


### PR DESCRIPTION
Refs IsraelHikingMap/Site#2509; implements the two fixes measured in https://github.com/IsraelHikingMap/planet-search/issues/90#issuecomment-4995601418 (opened per your go-ahead there).

## The two commits

1. **`latin_apostrophes` char filter** in the shared analyzer chain (U+0027, U+2018, U+2019, U+02BC → removed). US toponyms are split between GNIS spelling (Pikes Peak, Devils Lake) and apostrophized OSM names (Pike's Peak, Devil's Lake State Park), with both straight and curly apostrophes in the wild. The exact-name keyword tier treated these as different strings, so the exact bonus landed on whichever same-named feature happened to match the query's spelling — often the wrong continent, and raising the bonus only made the wrong side win harder. Folding at index and query time makes them one string. Hebrew is untouched (the filter only eats apostrophes; E2E incl. the FAR-* Hebrew cases is green).
2. **Exact-name bonus 0.5 → 0.8**, safe once the bonus always lands on the intended entity.

## Measured (full-planet index, 314-case gold set, stored template)

| variant | gold |
|---|---|
| current | 307/314 |
| bonus 0.8 without the fold | 306 — X011a/NIK-4 break on the apostrophe split |
| **this PR (fold + 0.8)** | **309/314** — FF01 הר מירון, FF03 עין גדי, FF08 Denali, FF10 Grand Canyon National Park all green |
| bonus 1.0+ | 296 — 0.8 is the sweet spot |

Prominence-scaled bonus variants were also measured and rejected (297→252: famous far towns start winning everywhere).

## Deploy note

The analyzer change takes effect on the next reindex, and the 0.8 bonus should ship **together with it** — on a pre-fold index 0.8 alone re-breaks X011a/NIK-4.
