### PR TITLE
Improve exact match

### DIFF
--- a/src/main/resources/search-templates/points_search.json
+++ b/src/main/resources/search-templates/points_search.json
@@ -128,6 +128,19 @@
                 },
                 "weight": 0.8
               }
+              {{^prefix}}
+              ,{
+                "filter": {
+                  "bool": {
+                    "minimum_should_match": 1,
+                    "should": [[[#languages]]
+                      { "match": { "name.[[lang]]": { "query": "{{searchTerm}}", "operator": "and" } } }[[/languages]]
+                    ]
+                  }
+                },
+                "weight": 1.5
+              }
+              {{/prefix}}
               {{#hasCenter}}
               ,{
                 "script_score": {


### PR DESCRIPTION
@sergeytkachenko this is what a conversation with an AI brought up in order to solve the נחל הקיבוצים and בור עכסה entries.
I'm not sure if this is the right fix, so I would really appreciate your input here.

Also worth noting that I'm OK if an exact match like zion shows first when using the search term zion and not getting zion national park first (assuming it's at least in the first few, but also OK if it's not as it's OK for the user to continue typing to get the right results).

In any case, I would really appreciate your input here.
